### PR TITLE
fixing documentation h1 style

### DIFF
--- a/src/stylesheets/common/_documentation.scss
+++ b/src/stylesheets/common/_documentation.scss
@@ -12,8 +12,8 @@
   padding: 40px 20px;
 
   h1 {
-    font-family: 'Playfair Display';
     padding-top: 20px,
+    color: #fff
   }
 
   p {


### PR DESCRIPTION
- Documentation h1 style is showing as primary color (Red), fixing it with more specified selector
