### PR TITLE
Remove "block" display style from blog post tables

### DIFF
--- a/src/stylesheets/common/_posts.scss
+++ b/src/stylesheets/common/_posts.scss
@@ -34,8 +34,8 @@
   table {
     width: 100%;
     border: 2px solid $table-border-color;
-    display: block;
     word-break: break-all;
+
     @media (min-width: $screen-sm-min) {
       width: 100%;
       word-break: keep-all;


### PR DESCRIPTION
Tables should retain their default `display: table` property or weird things happen
