### PR TITLE
fixing path pointing to mapzen.com

### DIFF
--- a/src/site/fragments/global-footer.html
+++ b/src/site/fragments/global-footer.html
@@ -2,7 +2,7 @@
   <div class='container hidden-print'>
     <div class='row headroom-extra-large'>
       <div class='col-xs-12 text-center'>
-        <img src='/resources/compass-lg-red.png'>
+        <img src='https://mapzen.com/resources/compass-lg-red.png'>
         <h5 class="headroom">Get involved</h5>
       </div>
     </div>
@@ -21,7 +21,7 @@
     <div class='container'>
       <div class='row headroom'>
         <div class='col-xs-12 text-center'>
-          <img height='81px' src='/resources/mapzen_logo@2x.png'>
+          <img height='81px' src='https://mapzen.com/resources/mapzen_logo@2x.png'>
           <div class='text-18 gray-text headroom'>
             <span class='slogan'>start where you are</span>
           </div>


### PR DESCRIPTION
- asset path is now pointing to mapzen.com ( not styleguide local)
- When we first started styleguide, we decided to make all assets pointing to `mapzen.com/resources`, so we don't have to have rendundant assets folders scattered out. Maybe this resource folder should be inside of styeguide, but for now, we use `mapzen.com/resources` path so we can move everything together when we decided to do this.
- closes #149 
