### PR TITLE
getting rid of octocat from icons

### DIFF
--- a/src/site/design-elements/icons/index.html
+++ b/src/site/design-elements/icons/index.html
@@ -39,10 +39,6 @@
           <td class="text-center"><img src="./images/key.png"></td>
           <td>Key</td>
         </tr>
-        <tr>
-          <td class="text-center"><img src="./images/octocat.png"></td>
-          <td>Github Octocat</td>
-        </tr>
       </tbody>
     </table>
 


### PR DESCRIPTION
- Octocat is licensed under Github, so I think it is better not to put under our styleguide ?
