### PR TITLE
Table stuff.

### DIFF
--- a/dist/samples/blog-post.html
+++ b/dist/samples/blog-post.html
@@ -97,6 +97,101 @@
 
 <p>As one of the earliest adopters of Mapzen Search, <a href="https://www.gaiagps.com">Gaia GPS</a> has been pioneering new uses for the tool for months! Since we’ve been in beta, Gaia GPS has been helping hikers, bikers, and other outdoor explorers remember their outdoor adventures, using our <a href="https://mapzen.com/documentation/search/reverse/">reverse geocoding</a> to name their custom trails.</p>
 
+<table><thead>
+<tr>
+<th style="text-align: center"></th>
+<th style="text-align: center">Grocery Points of Interest<sup>*</sup></th>
+<th style="text-align: center">with Addresses</th>
+<th style="text-align: center">with Website</th>
+<th style="text-align: center">with Hours</th>
+</tr>
+</thead><tbody>
+<tr>
+<td style="text-align: center"><strong>Auckland</strong></td>
+<td style="text-align: center">337</td>
+<td style="text-align: center">6%</td>
+<td style="text-align: center">1%</td>
+<td style="text-align: center">1%</td>
+</tr>
+<tr>
+<td style="text-align: center"><strong>Dublin</strong></td>
+<td style="text-align: center">690</td>
+<td style="text-align: center">14%</td>
+<td style="text-align: center">4%</td>
+<td style="text-align: center">5%</td>
+</tr>
+<tr>
+<td style="text-align: center"><strong>Hong Kong</strong></td>
+<td style="text-align: center">496</td>
+<td style="text-align: center">6%</td>
+<td style="text-align: center">1%</td>
+<td style="text-align: center">3%</td>
+</tr>
+<tr>
+<td style="text-align: center"><strong>Melbourne</strong></td>
+<td style="text-align: center">220</td>
+<td style="text-align: center">35%</td>
+<td style="text-align: center">30%</td>
+<td style="text-align: center">17%</td>
+</tr>
+<tr>
+<td style="text-align: center"><strong>Mexico City</strong></td>
+<td style="text-align: center">702</td>
+<td style="text-align: center">8%</td>
+<td style="text-align: center">1%</td>
+<td style="text-align: center">6%</td>
+</tr>
+<tr>
+<td style="text-align: center"><strong>Mumbai</strong></td>
+<td style="text-align: center">119</td>
+<td style="text-align: center">7%</td>
+<td style="text-align: center">2%</td>
+<td style="text-align: center">2%</td>
+</tr>
+<tr>
+<td style="text-align: center"><strong>San Francisco</strong></td>
+<td style="text-align: center">715</td>
+<td style="text-align: center">47%</td>
+<td style="text-align: center">18%</td>
+<td style="text-align: center">15%</td>
+</tr>
+<tr>
+<td style="text-align: center"><strong>São Paulo</strong></td>
+<td style="text-align: center">806</td>
+<td style="text-align: center">22%</td>
+<td style="text-align: center">6%</td>
+<td style="text-align: center">3%</td>
+</tr>
+<tr>
+<td style="text-align: center"><strong>Seoul</strong></td>
+<td style="text-align: center">1,069</td>
+<td style="text-align: center">2%</td>
+<td style="text-align: center">0.3%</td>
+<td style="text-align: center">1%</td>
+</tr>
+<tr>
+<td style="text-align: center"><strong>Singapore</strong></td>
+<td style="text-align: center">343</td>
+<td style="text-align: center">12%</td>
+<td style="text-align: center">6%</td>
+<td style="text-align: center">5%</td>
+</tr>
+<tr>
+<td style="text-align: center"><strong>Stockholm</strong></td>
+<td style="text-align: center">673</td>
+<td style="text-align: center">18%</td>
+<td style="text-align: center">17%</td>
+<td style="text-align: center">34%</td>
+</tr>
+<tr>
+<td style="text-align: center"><strong>Vancouver</strong></td>
+<td style="text-align: center">193</td>
+<td style="text-align: center">38%</td>
+<td style="text-align: center">11%</td>
+<td style="text-align: center">11%</td>
+</tr>
+</tbody></table>
+
 <p>They just rolled the feature out into <a href="https://www.gaiagps.com/apps/ios/">their iOS app</a>, so if you’re planning an outdoor adventure and want to plan or log your journey, know that Mapzen Search is there to help you find yourself in GaiaGPS.</p>
 
 <h2 id="meshu">Meshu</h2>

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -23,6 +23,7 @@ var social = require('./social.js');
 var stickynav = require('./sticky-nav.js');
 var activelink = require('./active-nav-link.js');
 var sidenav = require('./side-nav.js');
+var tablewrap = require('./table-wrap.js');
 
 // Create a global MPZN object
 // Inherit it if already present from elsewhere

--- a/src/scripts/table-wrap.js
+++ b/src/scripts/table-wrap.js
@@ -1,0 +1,48 @@
+// (c) 2016 Mapzen
+// LICENSE: MIT
+//
+// TABLES & TABLE WRAPPING
+//
+// Ensures that tables have .table class when needed.
+// Wraps tables in an element that permits horizontal
+// scrolling if they are too wide for its parent column.
+// --------------------------------------------------------
+(function (root, factory) {
+  // Universal Module Definition (UMD)
+  // via https://github.com/umdjs/umd/blob/master/templates/returnExports.js
+  if (typeof module === 'object' && module.exports) {
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like environments that support module.exports,
+    // like Node.
+    module.exports = factory();
+  } else {
+    // Browser globals (root is window)
+    root.returnExports = factory();
+  }
+}(this, function () {
+  'use strict';
+
+  // Tables inside of .content or .static-content divs should automatically
+  // take on the .table class. Here, we apply them client-side.
+  var tables = document.querySelectorAll('.content table, .static-content table');
+  for (var i = 0, j = tables.length; i < j; i++) {
+    tables[i].classList.add('table');
+  }
+
+  // Wrap all tables in a container that permits horizontal scrolling if they
+  // are too wide for its parent column.
+  var tableEls = document.querySelectorAll('.table');
+
+  for (var i = 0, j = tableEls.length; i < j; i++) {
+    var el = tableEls[i];
+    var wrapper = document.createElement('div');        // Create wrapper
+    wrapper.className = 'table-wrapper';                // It's called .table-wrapper
+    el.parentNode.insertBefore(wrapper, el);            // Insert it into document where table is
+    wrapper.appendChild(el.parentNode.removeChild(el)); // Move the table into the wrapper
+  }
+
+  // Just return a value to define the module export.
+  // This example returns an object, but the module
+  // can return a function as the exported value.
+  return {};
+}));

--- a/src/scripts/table-wrap.js
+++ b/src/scripts/table-wrap.js
@@ -35,10 +35,13 @@
 
   for (var i = 0, j = tableEls.length; i < j; i++) {
     var el = tableEls[i];
-    var wrapper = document.createElement('div');        // Create wrapper
-    wrapper.className = 'table-wrapper';                // It's called .table-wrapper
-    el.parentNode.insertBefore(wrapper, el);            // Insert it into document where table is
-    wrapper.appendChild(el.parentNode.removeChild(el)); // Move the table into the wrapper
+    // Only do this if not already wrapped.
+    if (el.parentNode.classList.contains('table-wrapper') === false) {
+      var wrapper = document.createElement('div');        // Create wrapper
+      wrapper.className = 'table-wrapper';                // It's called .table-wrapper
+      el.parentNode.insertBefore(wrapper, el);            // Insert it into document where table is
+      wrapper.appendChild(el.parentNode.removeChild(el)); // Move the table into the wrapper
+    }
   }
 
   // Just return a value to define the module export.

--- a/src/site/design-elements/tables/index.html
+++ b/src/site/design-elements/tables/index.html
@@ -1,5 +1,21 @@
 <div id="tables" class="headroom-large">
   <h5>Tables</h5>
+
+  <p>
+    Tables can be written in HTML, as in the snippet below. In projects that support Markdown, tables can be created in <a href="https://help.github.com/articles/github-flavored-markdown/#tables">GitHub-flavored Markdown syntax</a>, and they will be rendered in the same way.
+  </p>
+
+  <p>
+    Tables can extend horizontally beyond the width of the column it's in. When this happens, a scrollbar is added to allow the table to scroll horizontally without breaking the page layout. To minimize this effect, consider the following content guidelines:
+  </p>
+
+  <ul>
+    <li>Avoid writing extremely long, unbreakable strings of text, such as <code>very_long_variable_names</code>. You can force variable names to break in the middle of words by applying a <code>.table-word-break</code> class to the table element (not available in Markdown).
+    <li>Similarly, avoid showing full URL strings. URLs should be written as links with readable text labels.</li>
+    <li>Keep the number of columns to the minimum necessary to convey information. It may be desirable to present information across several tables instead of one large table.</li>
+    <li>Not all information is best presented as tables. Consider whether this data is tabular in nature and if there are other ways of presenting it. See the <a href="http://localhost:8080/resources.html#content-guides">content guidelines</a> for more information.</li>
+  </ul>
+
   <div data-xrayhtml>
     <table class="table">
       <thead>

--- a/src/site/design-elements/tables/index.html
+++ b/src/site/design-elements/tables/index.html
@@ -2,19 +2,10 @@
   <h5>Tables</h5>
 
   <p>
-    Tables can be written in HTML, as in the snippet below. In projects that support Markdown, tables can be created in <a href="https://help.github.com/articles/github-flavored-markdown/#tables">GitHub-flavored Markdown syntax</a>, and they will be rendered in the same way.
+    Tables can be written in HTML, as in the snippet below. To ensure that it picks up the correct styling and behavior, add the <code>.table</code> class to the table element. In projects that support Markdown, tables can be created in <a href="https://help.github.com/articles/github-flavored-markdown/#tables">GitHub-flavored Markdown syntax</a>, and they will be rendered in the same way.
   </p>
 
-  <p>
-    Tables can extend horizontally beyond the width of the column it's in. When this happens, a scrollbar is added to allow the table to scroll horizontally without breaking the page layout. To minimize this effect, consider the following content guidelines:
-  </p>
-
-  <ul>
-    <li>Avoid writing extremely long, unbreakable strings of text, such as <code>very_long_variable_names</code>. You can force variable names to break in the middle of words by applying a <code>.table-word-break</code> class to the table element (not available in Markdown).
-    <li>Similarly, avoid showing full URL strings. URLs should be written as links with readable text labels.</li>
-    <li>Keep the number of columns to the minimum necessary to convey information. It may be desirable to present information across several tables instead of one large table.</li>
-    <li>Not all information is best presented as tables. Consider whether this data is tabular in nature and if there are other ways of presenting it. See the <a href="http://localhost:8080/resources.html#content-guides">content guidelines</a> for more information.</li>
-  </ul>
+  <h3 class="headroom-large footroom">Basic table</h3>
 
   <div data-xrayhtml>
     <table class="table">
@@ -60,4 +51,93 @@
       </tbody>
     </table>
   </div>
+
+  <h3 class="headroom-large footroom">Extra wide tables</h3>
+
+  <p>
+    Tables will attempt to fit in the space it's allotted. However, if a table’s content prevents it from fitting, then the table is allowed to scroll horizontally so that it cannot break the page layout. This is made possible by a <code>&lt;div class=".table-wrapper"&gt;</code> element that wraps the table element. If you do not provide this element yourself, we will automatically add one.
+  </p>
+
+  <div data-xrayhtml>
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Craft</th>
+          <th>Type</th>
+          <th>Length</th>
+          <th>Weapons</th>
+          <th>Crew</th>
+          <th>Top Speed</th>
+          <th>Troop Capacity</th>
+          <th>Cargo Capacity</th>
+          <th>Passengers</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Modified YT-1300 Corellian Transport</td>
+          <td>Stock Light Freighter</td>
+          <td>27 Meters</td>
+          <td>2 Quad Laser Cannons, 2 Concussion Missile Launchers, 1 Retractable Light Laser Cannon</td>
+          <td>2</td>
+          <td>100 MGLT</td>
+          <td>6</td>
+          <td>100 Metric Tons</td>
+          <td>6</td>
+        </tr>
+        <tr>
+          <td>Imperial I-class Star Destroyer</td>
+          <td>Star Destroyer</td>
+          <td>1,600 Meters</td>
+          <td>60 Turbolasers Cannons, 60 Ion Cannons, 10 Tractor Beam Projectors</td>
+          <td>36,810 On-Board Personnel, 275 Gunners</td>
+          <td>60 MGLT</td>
+          <td>9,700 Ground Troops</td>
+          <td>36,000 Metric Tons, 0 AT-ATs, 30 AT-STs, 72 TIE Fighters, 5 Assault Gunboats, 8 Lambda-class Imperial Shuttles, 15 Imperial Landing Craft, 12 Landing Barges</td>
+          <td>9,700</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <p>
+    If you do not desire the horizotal scroll and wish to minimize its effect, consider the following content guidelines:
+  </p>
+
+  <ul>
+    <li>Avoid writing extremely long, unbreakable strings of text, such as <code>very_long_variable_names</code>. You can force long variable names to break by applying a <code>.table-word-break</code> class to the table element (see below; this is not available in Markdown).
+    <li>Similarly, avoid showing full URL strings. URLs should be written as links with readable text labels.</li>
+    <li>Keep the number of columns to the minimum necessary to convey information. It may be desirable to present information across several tables instead of one large table.</li>
+    <li>Not all information is best presented as tables. Consider whether this data is tabular in nature and if there are other ways of presenting it. See the <a href="http://localhost:8080/resources.html#content-guides">content guidelines</a> for more information.</li>
+    <li>On mobile devices, this behavior may be necessary and unavoidable.</li>
+  </ul>
+
+  <h3 class="headroom-large footroom">Breaking code blocks in tables</h3>
+
+  <p>
+    Currently, we do not implement word breaking or hyphenation, due to poor cross-browser support. However, it may be desirable in some situations to break code elements containing <code>long_variable_names_such_as_this_one</code> with minimal impact on readability. This is available by adding a <code>.table-word-break</code> class to the table element, and it takes effect <em>only</em> on screens smaller than 768 pixels wide (e.g. on mobile devices). It must be written in HTML manually; it is not available for tables that are generated through Markdown.
+  </p>
+
+  <div data-xrayhtml>
+    <table class="table table-word-break">
+      <thead>
+        <tr>
+          <th>Variable name</th>
+          <th>Value</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>this_is_the_first_extremely_long_variable_for_this_example_table</code></td>
+          <td>Star Destroyer</td>
+        </tr>
+        <tr>
+          <td><code>this_is_the_second_extremely_long_variable_for_this_example_table</code></td>
+          <td>Stock Light Freighter</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+
 </div>

--- a/src/stylesheets/common/_posts.scss
+++ b/src/stylesheets/common/_posts.scss
@@ -27,39 +27,16 @@
     padding: 0px;
   }
 
-  //table style, overwrapping with documentation site's table other than width & mobile behaviour
-  //on mobile, it breaks down the word to keep its width fit to container.
-
-  //** we need to remove these table styles and start using styleguide styles. The only difference is the negative margin**
-  table {
-    width: 100%;
-    border: 2px solid $table-border-color;
-    word-break: break-all;
-
-    @media (min-width: $screen-sm-min) {
-      width: 100%;
-      word-break: keep-all;
-    }
-
+  // Wider table area on wider screens.
+  .table-wrapper {
     @media (min-width: $screen-md-min) {
-      width: 120%;
       margin-left: -10%;
-    }
-
-    th {
-      border-right: 1px dotted $table-border-color;
-      border-bottom: 2px solid $table-border-color;
-      padding: 8px;
-    }
-    td {
-      border-top:  1px solid $table-border-color;
-      border-right: 1px dotted $table-border-color;
-      padding: 8px;
-      font-size: 0.9em;
-      line-height: 1.1;
-      vertical-align: top;
+      margin-right: 10%;
+      max-width: 120%;
+      width: 120%;
     }
   }
+
   // These DOM elements are generated from (the non-standard) Markdown footnotes syntax
   // via the Redcarpet extension. If the Markdown parser changes, please check to make
   // sure these selectors will still be valid.

--- a/src/stylesheets/common/_tables.scss
+++ b/src/stylesheets/common/_tables.scss
@@ -2,6 +2,7 @@
   width: 100%;
   border: 2px solid $table-border-color;
   margin-bottom: 0;
+  font-size: $body-small;
 
   th {
     font-family: $docs-heading-font;
@@ -17,7 +18,14 @@
     border-right: 1px dotted $table-border-color;
     border-top:  1px solid $table-border-color;
   }
+}
 
+// Apply this class to a table if you want to permit
+// word break rules. Currently this is pretty scoped: it
+// only forces breaks inside code strings when the viewport
+// is smaller. In the future, this may have add word breaks
+// and hyphenations to text, depending on browser support.
+.table-word-break {
   // Break long code strings in table cells on small windows
   @media (max-width: 768px) {
     td code {

--- a/src/stylesheets/common/_tables.scss
+++ b/src/stylesheets/common/_tables.scss
@@ -31,6 +31,10 @@
     td code {
       word-break: break-word;
       overflow-wrap: break-word;
+
+      // Cleaner break; non-standard & webkit only
+      -webkit-box-decoration-break: clone;
+      box-decoration-break: clone;
     }
   }
 }

--- a/src/stylesheets/common/_variables.scss
+++ b/src/stylesheets/common/_variables.scss
@@ -24,6 +24,7 @@ $docs-heading-font: 'Montserrat', 'Open Sans', sans-serif;
 $docs-accent-font: 'Montserrat', 'Open Sans', sans-serif;
 
 $body-small: 14px;
+$body-large: 18px; // Currently not used
 
 // Links
 $link-hover-decoration: none;


### PR DESCRIPTION
This is a pretty big deal.
- Table guidelines (as discussed today) are added to the styleguide.
- Wrapping text in code elements inside of tables are now optionally enabled via a `.table-word-break` class applied to the table itself.
- Tables adopt the `$body-small` font size to conserve space.
- All tables in Jekyll generated content pick up the `.table` base class. This is done via the styleguide's bundled JavaScript.
- Additionally, all `.table`s are wrapped in `.table-wrapper` div to allow horizontally scrolling of the table if it is too wide to fit in the viewport.
- This allows us to remove the duplicate `table` styles in the blog post CSS file, with the exception of styling the wrapper to allow it to be wider than content column on larger screns.
- @IndyHurt's table, as generated by Markdown, is added to `samples/blog-post.html` as a demonstration of how this works in practice. Once this is live, the temporary workarounds added to her blog post should be removed.

cc @souperneon @hanbyul-here @migurski 
