### PR TITLE
hack to avoid bootstrap affix <= bug

### DIFF
--- a/src/scripts/side-nav.js
+++ b/src/scripts/side-nav.js
@@ -48,6 +48,11 @@
       offset: {
         top: function () {
           var navHeight = nav ? nav.offsetHeight : 0;
+          // in bootstrap/affix.js line 45 there appears to be an off by 1 bug
+          // which in some layouts causes the affix to incorrectly toggle
+          // on mouseclick if the screen is scrolled all the way to the top
+          // see: http://stackoverflow.com/questions/19711202/bootstrap-3-affix-plugin-click-bug
+          // to avoid this we're adding 1 to offset.top
           return $(container).offset().top - navHeight + 1;
         },
         bottom: function () {

--- a/src/scripts/side-nav.js
+++ b/src/scripts/side-nav.js
@@ -48,7 +48,7 @@
       offset: {
         top: function () {
           var navHeight = nav ? nav.offsetHeight : 0;
-          return $(container).offset().top - navHeight;
+          return $(container).offset().top - navHeight + 1;
         },
         bottom: function () {
           return $(document).height() - $(container).offset().top - $(container).outerHeight(true);


### PR DESCRIPTION
closes #205

here are some examples of people's solutions for this bug: http://stackoverflow.com/questions/19711202/bootstrap-3-affix-plugin-click-bug
