### PR TITLE
Adding more general name for elements used for jobs page to reuse

### DIFF
--- a/src/stylesheets/common/_doc-hitboxes.scss
+++ b/src/stylesheets/common/_doc-hitboxes.scss
@@ -59,3 +59,11 @@
     margin-top: 1em;
   }
 }
+
+.cta-paragraph {
+  font-weight: 300;
+}
+
+.docs-title {
+  font-size: 20px;
+}

--- a/src/stylesheets/common/_job-list.scss
+++ b/src/stylesheets/common/_job-list.scss
@@ -24,13 +24,13 @@
     @media (max-width: $screen-xs-max) {
       padding: 20px 0px;
     }
-    // using different border style for first element of each team 
+    // using different border style for first element of each team
     &.first { border-top: 2px solid #ccc; }
 
     .job-info {
       display: table-cell;
       @media (max-width: $screen-xs-max) { display: table-row; }
-      
+
       .location {
         font-size: 14px;
         //adding interpunct only on large screen
@@ -66,3 +66,65 @@
   }
 }
 
+
+
+
+//overwriting h6 to use as team name
+h6.category-title {
+  font-family: 'Playfair Display';
+  font-weight: 600;
+  font-size: 1.5em;
+  line-height: 1.5;
+  color: $mz-mediumgray;
+  text-transform: capitalize;
+}
+
+.category-info-container {
+  width: 100%;
+  display: table;
+  border-top: 1px dotted #ccc;
+  padding: 25px 0px;
+  font-size: 16px;
+  color: #666;
+  @media (max-width: $screen-xs-max) {
+    padding: 20px 0px;
+  }
+  // using different border style for first element of each team
+  &.first { border-top: 2px solid #ccc; }
+
+  .category-info {
+    display: table-cell;
+    @media (max-width: $screen-xs-max) { display: table-row; }
+
+    .sub-info {
+      font-size: 14px;
+      //adding interpunct only on large screen
+      &:before { content: '·';}
+      @media (max-width: $screen-xs-max) {
+        display: block;
+        line-height: 1.8;
+        &:before {
+          content: none;
+        }
+      }
+    }
+
+    .excerpt {
+      @media (max-width: $screen-xs-max) {
+        margin-bottom: 20px;
+      }
+    }
+  }
+
+  .read-more {
+    display: table-cell;
+    vertical-align: middle;
+    width: 150px;
+    text-align: center;
+    text-transform: capitalize;
+    @media (max-width: $screen-xs-max) {
+      display: table-row;
+      padding: 10px 0;
+    }
+  }
+}


### PR DESCRIPTION
- Now Docs page will use jobs page's class, so generalizing the name for the classes
- related prs : https://github.com/mapzen/website/pull/1083, https://github.com/mapzen/mapzen-docs-generator/pull/162
- Merge this one first please @rmglennon 
