### PR TITLE
Updates to the writing style guides

### DIFF
--- a/src/site/guides/common-terms-and-conventions.md
+++ b/src/site/guides/common-terms-and-conventions.md
@@ -1,32 +1,55 @@
-#Common terms and writing conventions
+# Common terms and writing conventions
 
-Use this style guide in conjunction with other sources of style information, such as a dictionary like [Merriam-Webster](http://www.merriam-webster.com/), the Microsoft Manual of Style (available in print only), and the [Apple Style Guide](https://help.apple.com/asg/mac/2013/ASG_2013.pdf). For example, if you want to know how to refer to an item in Mac OS, defer to the term Apple uses for it. This document brings together some of the most commonly encountered terms from those other guides, and may add Mapzen flavor to them.
+Use this style guide in conjunction with other sources of style information, such as a dictionary like [Merriam-Webster](http://www.merriam-webster.com/), the Microsoft Manual of Style (available in print only), and the [Apple Style Guide](https://help.apple.com/asg/mac/2013/ASG_2013.pdf), or the Associated Press Stylebook (available with a subscription). For example, if you want to know how to refer to an item in Mac OS, defer to the term Apple uses for it. This document brings together some of the most commonly encountered terms from those other guides, and may add Mapzen flavor to them.
 
-This list is a living document that will be added to or changed as terminology is encountered. The document is public, so you can also add your own content to it.
+This list is a living document that will be added to or changed as terminology is encountered.
 
-##Numbers
+## Numbers, times, and dates
+
 - Spell out one through nine unless it precedes a unit or is to be input, write the numerals for 10 and above.
+- Use numerals for all measurements.
+- Use 24-hour times, if you can, to consider a global audience.
+- Use [ISO standards](https://en.wikipedia.org/wiki/ISO_8601) for calendar dates because this is the common format Mapzen uses in developer contexts and code. Example: _YYYY-MM-DD_, or _2016-09-05_ for September 5, 2016. Note that this diverges from Microsoft style, which is _month day, year_.
 
-##Computing terms
-- You "sign in" or "sign off" when accessing an account. You "log on" or "log out" of a operating system session.
-- Hosting within your organization is "on-premises". It always has a hyphen and an -s.
-- email is one word, no hyphen.
+## User interface elements
+
+- When interacting with a user interface, you _click_ an item that you expect to be in a desktop context. For documentation about mobile products, you can use _tap_ an item. Use _press_ only when referring to items that you physically press, such as keys on a keyboard.
+- When describing cascading menus or breadcrumbs, it is okay to use the caret symbol (>) to show the hierarchy. For example, _click File > New Tab_.
+- In most cases, you do not need to add a description of the user interface element. For example, _click Download_, instead of _click the Download button_. This simplifies the documentation and avoids ambiguity over what to call the particular element.
+
+## Open source and open-source (and other cases of hyphenation)
+
+- Whether or not to hyphenate depends on how these terms are used.
+- When open source is a compound adjective, which is an adjective made up of multiple words, you should hyphenate. For example, in _open-source software_ or _open-source project_, you should use a hyphen.
+- Do not use a hyphen with in a sentence such as, "The code is open source."
+- You do not need to use a hyphen with adverbs, such as "a beautifully created map".
+- Follow the same guidelines when writing with other adjectives, compound adjectives, and adverbs. For example: _real-time communication_ versus _the communication is in real time_.
+
+## Computing terms
+
+- You _sign in_ or _sign off_ when accessing an account. You _log on_ or _log out_ of a operating system session.
+- Hosting within your organization is _on-premises_. It always has a hyphen and an -s.
+- email (n.) is one word, no hyphen. Use "send an email message", rather than "email" as a verb.
 - File format abbreviations (PDF, JPEG) should be in uppercase, and filename extensions (.pdf, .jpeg) in lowercase.
 - filename is one word
 - Finder is the application for browsing folders on a Mac. Apple says to use it as "the Finder", not "Finder".
-- administrator should not be shortened to "admin"
+- administrator should not be shortened to "admin".
 - plug-in (n., related to extending functionality, such as for a browser) always has a hyphen. Plug in (v.) without a hyphen describes the action of plugging in a cable.
+- The words, internet and web, are lowercase. These have historically been capitalized because they were proper nouns, but the [AP changed this in June 2016](https://twitter.com/apstylebook/status/716279065888563200).
 
-##Abbreviations and acronyms
-- Spell out a term if you think the audience does not know it. Put the spelled-out term first and the acronym in parentheses, such as Internet Service Provider (ISP).
-- Do not add an apostrophe if you make acronym plural (for example, DVDs not DVD's).
+## Abbreviations and acronyms
+
+- Spell out a term if you think the audience does not know it. Put the spelled-out term first and the acronym in parentheses, such as API (application programming interface). In most cases, the words that form the acronym or abbreviation are not capitalized.
+- Do not add an apostrophe if you make acronym plural (for example, DVDs not DVD's, 1980s not 1980's).
 - Abbreviate MB and GB
 - Avoid using Latin words, such as e.g., i.e., et al., and etc. Instead, use for example, that is, and others, and so on.
-- Do not use the ampersand symbol & in text to mean "and". It is okay to use it in appropriate contexts, such as in code samples.
+- Do not use the ampersand symbol (&) in text to mean _and_. In that case, spell out the word and. It is okay to use & in appropriate contexts, such as in code samples.
 
-##Titles and headings
-- Use sentence-style capitalization (First word capitalized), rather than title case (All Words Capitalized). Sentence-style is easier to read.
-- Use imperative verbs, rather than gerunds for titles and headings. For example, name a section, "Add a point to the map", rather than "Adding a point to the map". Imperative is clearer and easier to translate. Nouns are also acceptable for titles and headings.
+## Titles and headings
 
-##Common words
-- Because, since - use because for causation (because you checked your email, you saw the meeting invitation) and since for a period of time (it's been hours since you checked email).
+- Use sentence-style capitalization (_Only first word capitalized_), rather than title case (_Every, Single Word Gets Capitalized_). Sentence-style is easier to read, and words that are truly proper nouns stand out better.
+- Use imperative verbs, rather than gerunds for titles and headings. For example, name a section, "Add a point", rather than "Adding a point". Imperative is clearer and easier to translate. Nouns are also acceptable for titles and headings.
+
+## Common words
+
+- Because, since: use _because_ for causation (because you checked your email, you saw the meeting invitation) and _since_ for a period of time (it's been hours since you checked email).

--- a/src/site/guides/common-terms-and-conventions.md
+++ b/src/site/guides/common-terms-and-conventions.md
@@ -1,4 +1,4 @@
-# Common terms and writing conventions
+# Common general terms and writing conventions
 
 Use this style guide in conjunction with other sources of style information, such as a dictionary like [Merriam-Webster](http://www.merriam-webster.com/), the Microsoft Manual of Style (available in print only), and the [Apple Style Guide](https://help.apple.com/asg/mac/2013/ASG_2013.pdf), or the Associated Press Stylebook (available with a subscription). For example, if you want to know how to refer to an item in Mac OS, defer to the term Apple uses for it. This document brings together some of the most commonly encountered terms from those other guides, and may add Mapzen flavor to them.
 
@@ -6,36 +6,12 @@ This list is a living document that will be added to or changed as terminology i
 
 ## Numbers, times, and dates
 
-- Spell out one through nine unless it precedes a unit or is to be input, write the numerals for 10 and above.
+- Spell out one through nine unless it precedes a unit or is to be input.
+- Use numerals for 10 and above.
 - Use numerals for all measurements.
 - Use 24-hour times, if you can, to consider a global audience.
-- Use [ISO standards](https://en.wikipedia.org/wiki/ISO_8601) for calendar dates because this is the common format Mapzen uses in developer contexts and code. Example: _YYYY-MM-DD_, or _2016-09-05_ for September 5, 2016. Note that this diverges from Microsoft style, which is _month day, year_.
-
-## User interface elements
-
-- When interacting with a user interface, you _click_ an item that you expect to be in a desktop context. For documentation about mobile products, you can use _tap_ an item. Use _press_ only when referring to items that you physically press, such as keys on a keyboard.
-- When describing cascading menus or breadcrumbs, it is okay to use the caret symbol (>) to show the hierarchy. For example, _click File > New Tab_.
-- In most cases, you do not need to add a description of the user interface element. For example, _click Download_, instead of _click the Download button_. This simplifies the documentation and avoids ambiguity over what to call the particular element.
-
-## Open source and open-source (and other cases of hyphenation)
-
-- Whether or not to hyphenate depends on how these terms are used.
-- When open source is a compound adjective, which is an adjective made up of multiple words, you should hyphenate. For example, in _open-source software_ or _open-source project_, you should use a hyphen.
-- Do not use a hyphen with in a sentence such as, "The code is open source."
-- You do not need to use a hyphen with adverbs, such as "a beautifully created map".
-- Follow the same guidelines when writing with other adjectives, compound adjectives, and adverbs. For example: _real-time communication_ versus _the communication is in real time_.
-
-## Computing terms
-
-- You _sign in_ or _sign off_ when accessing an account. You _log on_ or _log out_ of a operating system session.
-- Hosting within your organization is _on-premises_. It always has a hyphen and an -s.
-- email (n.) is one word, no hyphen. Use "send an email message", rather than "email" as a verb.
-- File format abbreviations (PDF, JPEG) should be in uppercase, and filename extensions (.pdf, .jpeg) in lowercase.
-- filename is one word
-- Finder is the application for browsing folders on a Mac. Apple says to use it as "the Finder", not "Finder".
-- administrator should not be shortened to "admin".
-- plug-in (n., related to extending functionality, such as for a browser) always has a hyphen. Plug in (v.) without a hyphen describes the action of plugging in a cable.
-- The words, internet and web, are lowercase. These have historically been capitalized because they were proper nouns, but the [AP changed this in June 2016](https://twitter.com/apstylebook/status/716279065888563200).
+- Use [ISO standards](https://en.wikipedia.org/wiki/ISO_8601) for calendar dates in documentation because this is the common format Mapzen uses in developer contexts and code. Example: _YYYY-MM-DD_, or _2016-09-05_ for September 5, 2016.
+- It is okay to use _month day, year_ in social media or a blog post. However, even in less formal content, avoid ambiguous date formatting, such as 9/5, which could be interpreted as September 5 or May 9, depending on the locale.
 
 ## Abbreviations and acronyms
 
@@ -48,8 +24,10 @@ This list is a living document that will be added to or changed as terminology i
 ## Titles and headings
 
 - Use sentence-style capitalization (_Only first word capitalized_), rather than title case (_Every, Single Word Gets Capitalized_). Sentence-style is easier to read, and words that are truly proper nouns stand out better.
-- Use imperative verbs, rather than gerunds for titles and headings. For example, name a section, "Add a point", rather than "Adding a point". Imperative is clearer and easier to translate. Nouns are also acceptable for titles and headings.
+- Use imperative verbs, rather than gerunds for titles and headings. For example, name a section, "Add a point", rather than "Adding a point". Imperative is clearer and easier to translate.
+- Use _Get started_, rather than _Getting started_, in following with the gerund style.
+- Nouns or topic descriptions are acceptable for titles and headings, such as _Tutorial_, _Overview_, _API reference_, and _Datastore queries_. If you use a general word like _Tutorial_, make sure what the tutorial will be about is clear from the context of the help section.
 
-## Common words
+## Common words and phrases
 
 - Because, since: use _because_ for causation (because you checked your email, you saw the meeting invitation) and _since_ for a period of time (it's been hours since you checked email).

--- a/src/site/guides/computing-and-coding-terms.md
+++ b/src/site/guides/computing-and-coding-terms.md
@@ -1,0 +1,30 @@
+# Common computing and coding terms
+
+Follow these guidelines when writing about activities involving a computer or code.
+
+## User interface elements
+
+- When interacting with a user interface, you _click_ an item that you expect to be in a desktop context. For documentation about mobile products, you _tap_ an item.
+- Use _press_ only when referring to items that you physically press, such as keys on a keyboard. Do not write, "Press the button."
+- When describing cascading menus or breadcrumbs, it is okay to use the caret symbol (>) to show the hierarchy. For example, _click File > New Tab_.
+- In most cases, you do not need to add a description of the user interface element. For example, _click Download_, instead of _click the Download button_. This simplifies the documentation and avoids ambiguity over what to call the particular element.
+
+## Open source and open-source (and other cases of hyphenation)
+
+- Whether or not to hyphenate open source depends on how these terms are used.
+- When open source is a compound adjective, which is an adjective made up of multiple words, you should hyphenate. For example, you should use a hyphen for _open-source software_ or _open-source project_.
+- Do not use a hyphen with in a sentence such as, "The code is open source."
+- Do not use a hyphen with adverbs, such as "a beautifully created map".
+- Follow the same guidelines when writing with other adjectives, compound adjectives, and adverbs. For example: _real-time communication_ versus _the communication is in real time_.
+
+## Computing terms
+
+- You _sign in_ or _sign off_ when accessing an account. You _log on_ or _log out_ of a operating system session.
+- Hosting within your organization is _on-premises_. It always has a hyphen and an -s.
+- email (n.) is one word, no hyphen. Use "send an email message", rather than "email" as a verb.
+- File format abbreviations (PDF, JPEG) should be in uppercase, and filename extensions (.pdf, .jpeg) in lowercase.
+- filename is one word
+- Finder is the application for browsing folders on a Mac. Apple says to use it as "the Finder", not "Finder".
+- administrator should not be shortened to "admin".
+- plug-in (n., related to extending functionality, such as for a browser) always has a hyphen. Plug in (v.) without a hyphen describes the action of plugging in a cable.
+- The words, internet and web, are lowercase. These have historically been capitalized because they were proper nouns, but the [AP changed this in June 2016](https://twitter.com/apstylebook/status/716279065888563200).

--- a/src/site/guides/computing-and-coding-terms.md
+++ b/src/site/guides/computing-and-coding-terms.md
@@ -17,7 +17,7 @@ Follow these guidelines when writing about activities involving a computer or co
 - Do not use a hyphen with adverbs, such as "a beautifully created map".
 - Follow the same guidelines when writing with other adjectives, compound adjectives, and adverbs. For example: _real-time communication_ versus _the communication is in real time_.
 
-## Computing terms
+## General computing terms
 
 - You _sign in_ or _sign off_ when accessing an account. You _log on_ or _log out_ of a operating system session.
 - Hosting within your organization is _on-premises_. It always has a hyphen and an -s.
@@ -28,3 +28,7 @@ Follow these guidelines when writing about activities involving a computer or co
 - administrator should not be shortened to "admin".
 - plug-in (n., related to extending functionality, such as for a browser) always has a hyphen. Plug in (v.) without a hyphen describes the action of plugging in a cable.
 - The words, internet and web, are lowercase. These have historically been capitalized because they were proper nouns, but the [AP changed this in June 2016](https://twitter.com/apstylebook/status/716279065888563200).
+
+## Best practices for code samples
+
+In command line code blocks, do not include the $ or other prompt text before what the reader needs to type. If you copy the code, you end up pasting extra text. The exception to this is if you are showing a series of commands and responses when including the $ is useful to show which lines are input.

--- a/src/site/guides/doc-instructions.md
+++ b/src/site/guides/doc-instructions.md
@@ -4,11 +4,17 @@ You can get help at [mapzen.com/documentation](https://mapzen.com/documentation/
 
 This site brings together all Mapzen's documentation in one place. The underlying source help files are in GitHub, but display them in a way that is easy to navigate and visually pleasing. In addition, putting the help on mapzen.com connects it to the resources on the website, such as signing up for API keys.
 
-[mapzen-docs-generator](https://github.com/mapzen/mapzen-docs-generator) contains the configuration files and tools used to build the help system. Anytime there is a change to mapzen-docs-generator, CircleCI rebuilds the site. It also builds hourly to catch any changes in each documentation source repository.
+[mapzen-docs-generator](https://github.com/mapzen/mapzen-docs-generator) contains the configuration files and tools used to build the help system. Anytime there is a change to mapzen-docs-generator, CircleCI rebuilds the site. There is also a Heroku process that builds hourly to catch any changes in each documentation source repository.
+
+As long as a markdown file is listed in the build configuration, changes you make to the source files in the GitHub branch that is being pulled into the help (typically, the master branch) appear automatically on https://mapzen.com/documentation.
+
+## Build and deploy the help system website
+
+The help system is built with an open-source Python tool called [MkDocs](http://www.mkdocs.org/), which formats GitHub markdown files in to a static, HTML website. MkDocs also creates a table of contents, a simple keyword search, navigation breadcrumbs, and links to move back and forward between topics. Note that while MkDocs reads just one source, Mapzen has enhanced the generator to integrate multiple repositories. There have been additional enhancements to support URL redirects and renaming files in the output help.
 
 ## Update the table of contents
 
-To display on the documentation site, you need to add a topic to a configuration file to make it part of the help build process. Otherwise, the topic exists only in the repository. It is fine to have topics in the repository that are not in the help system, as long as you know that is happening.
+To display on the documentation site, you need to add a topic to a configuration file. Otherwise, the topic exists only in the repository. It is fine to have topics in the repository that are not in the help system, as long as you know that is happening.
 
 You need to update the config.yml file to add a topic, remove one, or rename it in the table of contents.
 
@@ -23,16 +29,76 @@ You need to update the config.yml file to add a topic, remove one, or rename it 
 
 Filenames are case-sensitive, so 'Scene-file.md' is different from 'scene-file.md'. The filename in the config file must exactly match the source file, or else you will get a build error.
 
-## Add URL redirects
+## Add URL redirects when you rename or move files
 
 Mapzen wrote some additional Python code to enable URLs to forward when files are renamed or moved. For example, the existing Turn-by-Turn, Optimized Route, and Matrix sections of the help were grouped under a Mobility section when they were packaged into a product called Mapzen Mobility. Because adding mobility changed the URLs, redirects allowed the previous topics to be found in the new help.
 
 For example, https://mapzen.com/documentation/turn-by-turn/api-reference/ redirects to https://mapzen.com/documentation/mobility/turn-by-turn/api-reference/ (note the mobility in the URL).
 
-## Rename or move files into a structure different from the source
+You will also need to do this when a file is removed or renamed in GitHub, and it has existed long enough that users may have bookmarked it or it can be found through search engines.
 
+1. Go to https://github.com/mapzen/mapzen-docs-generator/tree/master/config
+2. Find the .yml file for your section of help. For example, Mapzen Mobility can be found in mobility.yml.
+3. Look for a section named `mz:redirects:`. If one is not present, add it after the `pages:` section.
+4. Add a new line underneath, indent, and add the portion of the current URL to redirect, followed by a colon and the new URL.
 
+Here is a sample from the mobility.yml.
 
-## Build and deploy the help system website
+```
+mz:redirects:
+  'turn-by-turn': 'turn-by-turn/api-reference'
+  'matrix': 'matrix/api-reference'
+  'optimized': 'optimized/api-reference'
+```
 
-The help system is built with an open-source Python tool called [MkDocs](http://www.mkdocs.org/), which formats GitHub markdown files in to a static, HTML website. MkDocs also creates a table of contents, a simple keyword search, navigation breadcrumbs, and links to move back and forward between topics. Note that while MkDocs reads just one source, Mapzen has enhanced the generator to integrate multiple repositories.
+Behind the scenes, this calls setup-redirects.py during the build process.
+
+The base URL for all help is https://mapzen.com/documentation.
+This means that the base URL + left part of the colon is https://mapzen.com/documentation/turn-by-turn.
+
+When the script runs, the URL will redirect to the base URL + this section name from the config file (/mobility/) + the right side of the colon. This forms https://mapzen.com/documentation/mobility/turn-by-turn/api-reference.
+
+Similarly, for the `matrix` entry, https://mapzen.com/documentation/matrix will redirect to https://mapzen.com/documentation/mobility/matrix/api-reference.
+
+Note: you must use the redirects functionality anytime you are adding topics that fall under the mobility/turn-by-turn section of help because it takes on a different URL structure than the GitHub repository.
+
+Note: if you completely remove a section from the help, you should put your `mz:redirects` in the `index.yml` file. For example, the `turn-by-turn.yml` file was deleted during a product reorganization process, so redirects from that section of help are in `index.yml`.
+
+## Use a URL structure different from the source file organization
+
+MkDocs uses the exact file name and folder structure from the folder repository to build the URL for the help. This means that a file called `map_basics.md` becomes `/map_basics` with an underscore in the output documentation, when the URLs should ideally only have hyphens.
+
+If you group markdown files in a folder in GitHub, the files will also have this structure in the URL. For example, if you have a folder called `api-reference-docs` with a file in it called `map-basics.md`, the output URL will include `api-reference-docs/map-basics`. In some cases, this adds unnecessary complexity and inconsistency in the URLs.
+
+The simplest way around this is to rename or move the files in GitHub. When changing the source does not make sense, use the functions in the help build process.
+
+1. Go to https://github.com/mapzen/mapzen-docs-generator/tree/master/config
+2. Find the .yml file for your section of help. For example, Mapzen Mobility can be found in mobility.yml.
+3. Look for a section named `mz:renames:`. If one is not present, add it before the `pages:` section.
+4. Add a new line underneath, indent, and add the portion of the current URL to redirect, followed by a colon and the new path or filename.
+5. In the `pages:` section, use the new name of the file.
+
+Here is a sample from the mobility.yml.
+
+```
+mz:renames:
+  'optimized_route/api-reference.md': 'optimized/api-reference.md'
+  'api-reference.md': 'turn-by-turn/api-reference.md'
+```
+
+When the script runs, it will look in the GitHub source files for a folder named `optimized_route` (note the underscore) and a file in it called `api-reference.md`. It will then output to a temporary location during the build process a folder called `optimized` with the file in it still named `api-reference.md`. If you needed to rename the file, you could do that, too.
+
+In the second entry, it will look at the root level of the GitHub source for a file called `api-reference.md` and output it to a folder named `turn-by-turn`.
+
+## Add a new section to the help
+
+Adding an entirely new section of the help has many factors, ranging from design decisions on the mapzen.com website to the mechanics of building the help. Make sure the Products team is aware of your product or planned section of help, as adding a product is more than getting documentation posted on the website.
+
+In general, there are four files that you need to update to do this. In general, you can copy, paste, and modify existing files to understand what needs to be updated to add the new section.
+
+1. Add an entry to https://github.com/mapzen/mapzen-docs-generator/tree/master/src-index to update the index file that is the landing page for the documentation.
+2. Add a new config `.yml` file to https://github.com/mapzen/mapzen-docs-generator/tree/master/config. This builds the table of contents and sets the links to the source files so the `Edit this page on GitHub` links work properly (these allow users to go directly to the source file to propose edits).
+3. Update the Makefile in https://github.com/mapzen/mapzen-docs-generator/blob/master/Makefile that pulls together all resources for the help.
+4. Update the automated test at https://github.com/mapzen/mapzen-docs-generator/blob/master/run-checklist.py.
+
+If you are removing sections from the help, you will need to consider adding URL redirects to the `index.yml` file.

--- a/src/site/guides/doc-instructions.md
+++ b/src/site/guides/doc-instructions.md
@@ -2,22 +2,36 @@
 
 You can get help at [mapzen.com/documentation](https://mapzen.com/documentation/), or click `Documentation` in the top header on any page on [mapzen.com](https://mapzen.com) to take you there.
 
-This site brings together all Mapzen's documentation in one place. The underlying source help files are in GitHub, but display them in a way that is easy to navigate and visually pleasing. In addition, putting the help on mapzen.com connects it to the resources on the website, such as signing up for API keys. 
+This site brings together all Mapzen's documentation in one place. The underlying source help files are in GitHub, but display them in a way that is easy to navigate and visually pleasing. In addition, putting the help on mapzen.com connects it to the resources on the website, such as signing up for API keys.
 
 [mapzen-docs-generator](https://github.com/mapzen/mapzen-docs-generator) contains the configuration files and tools used to build the help system. Anytime there is a change to mapzen-docs-generator, CircleCI rebuilds the site. It also builds hourly to catch any changes in each documentation source repository.
 
-## Update the table of contents (add a topic, remove one, rename it in the table of contents)
+## Update the table of contents
 
-To display on the documentation site, you need to add a topic to a configuration file. Otherwise, the topic exists only in the repository.
+To display on the documentation site, you need to add a topic to a configuration file to make it part of the help build process. Otherwise, the topic exists only in the repository. It is fine to have topics in the repository that are not in the help system, as long as you know that is happening.
+
+You need to update the config.yml file to add a topic, remove one, or rename it in the table of contents.
 
 1. Go to https://github.com/mapzen/mapzen-docs-generator/tree/master/config
-2. Find the .yml file for your section of help. For example, Mapzen Turn-by-Turn can be found in turn-by-turn.yml.
-3. Under `pages:`, make the change to the table of contents. `Home:` should always be only `index.md.` Add topics by including a heading, contained in single quotation mark, followed by a colon and the name of the md file. For example, `'API Reference': 'api-reference.md'` 
-4. You can add nesting in the table of contents by indenting the lines underneath the heading. 
+2. Find the .yml file for your section of help. For example, Mapzen Mobility can be found in mobility.yml.
+3. Under `pages:`, make the change to the table of contents. The topic in the `Home:` position should always be only `index.md` (under MkDocs rules). Add topics by including a heading, contained in single quotation mark, followed by a colon and the name of the md file. For example, `'API Reference': 'api-reference.md'`
+4. You can add nesting in the table of contents by indenting the lines underneath the heading.
 ```json
 - Concept overviews:
   - 'The Scene File': 'Scene-file.md'
 ```
+
+Filenames are case-sensitive, so 'Scene-file.md' is different from 'scene-file.md'. The filename in the config file must exactly match the source file, or else you will get a build error.
+
+## Add URL redirects
+
+Mapzen wrote some additional Python code to enable URLs to forward when files are renamed or moved. For example, the existing Turn-by-Turn, Optimized Route, and Matrix sections of the help were grouped under a Mobility section when they were packaged into a product called Mapzen Mobility. Because adding mobility changed the URLs, redirects allowed the previous topics to be found in the new help.
+
+For example, https://mapzen.com/documentation/turn-by-turn/api-reference/ redirects to https://mapzen.com/documentation/mobility/turn-by-turn/api-reference/ (note the mobility in the URL).
+
+## Rename or move files into a structure different from the source
+
+
 
 ## Build and deploy the help system website
 

--- a/src/site/guides/maps.md
+++ b/src/site/guides/maps.md
@@ -25,10 +25,10 @@ Michael Evan's excellent [leaflet-hash](https://github.com/mlevans/leaflet-hash)
 [source / technology] | © OSM contributors | Mapzen
 ```
 
-- Source/technology might be Leaflet (required by Leaflet.js), Mapbox GL, Tangram, etc. More than one source or technology should be separated by a pipe (`|`) character.
+- Source/technology might be Leaflet, Mapbox GL, Tangram, etc. More than one source or technology should be separated by a pipe (`|`) character.
 - Do not modify the "© OSM contributors" segment.
 - Mapzen link should always be present and link to either the product site or the Mapzen main site.
 - Styles should match the Leaflet default placement, size, text color, link color, link hover behavior, and other applicable styles, even for map rendering libraries (MapboxGL, D3, etc) that don't include attribution controls by default. These styles should never be modified without good reason.
 - Attribution must never be hidden (this keeps us on good terms with the other contributors in the open source community we depend on)
 - Attribution links must always open on top of a demo's parent tab or window (`target='_top'`) if it originated in an iframe. [Here is a script to add targets to links](https://github.com/mapzen/ui/blob/master/components/utils/iframe.anchors.js), which is useful for links that are added programatically, like Leaflet's default attribution link. Do not use `target='_blank'`, unless circumstances demand it. When in doubt, refer to [this article on when to use target="_blank"](https://css-tricks.com/use-target_blank/).
-- Other links in an iframed demo may open on top of the parent tab or inside the iframe, depending on the circumstances. Again, avoid opening in a new window if you can help it.
+- Other links in an iframe demo may open on top of the parent tab or inside the iframe, depending on the circumstances. Again, avoid opening in a new window if you can help it.

--- a/src/site/guides/product-names.md
+++ b/src/site/guides/product-names.md
@@ -1,0 +1,18 @@
+# Product names
+
+## Common Mapzen names
+
+- Mapzen: Uppercase only the M. Do not write it as MapZen.
+- Mapzen.js: Stylized with a dot.
+- Turn-by-Turn: the Ts are capitalized, by is not, and there are hyphens in between.
+- Time-Distance Matrix: each word is capitalized and there is a hyphen between Time and Distance. Under some style guides, you might use an en dash here, but use a hyphen for simplicity.
+- Eraser Map: two words, both capitalized, with a space in between.
+- Transitland: Uppercase only the T. Note that the URL is https://transit.land, but use the dot notation only when referring to the website address.
+
+## Names from other organizations
+
+When using another organization's products or trademarks, always defer to their guidelines with spelling and capitalization. Do not make it sound like a product that is not from Mapzen is ours.
+
+- OpenStreetMap: the O, S, and M are always capitalized and there is no space between the words. Note also that is singular and there is no s at the end.
+- iOS, iPhone
+- JavaScript

--- a/src/site/guides/writing-style.md
+++ b/src/site/guides/writing-style.md
@@ -1,5 +1,26 @@
-- conversational tone, but be professional.
-- phrases and terms that are clear and easy to understand. Avoid idioms or phrasing that is unfamiliar to the audience or would not translate to other languages directly.
-- active voice is generally preferred over passive.
-- address the audience as "you" (second person. Avoid first person (I, we) and third person (the user, them). First person is acceptable in blogs or informal texts, but generally should be avoided in technical documentation. Using "you" also avoids the potential for gender-based terms, such as he or she.
-- in command line code blocks, do not include the $ or other prompt text before what the reader needs to type. If you copy the code, you end up pasting extra text. The exception to this is if you are showing a series of commands and responses when including the $ is useful to show which lines are input.
+# Voice and tone in technical documentation
+
+Technical documentation aims to be clear and concise, and through the use of standard writing styles, often attempts to have a single voice for all content. In general, the reader should be able to look at different sections of the documentation and find consistency, which aids in understanding.
+
+Even technical writing can still be engaging. For example, the routing examples in the Mapzen Turn-by-Turn tutorial mimics the roadtrip from the movie, National Lampoon's Vacation, but the reference is subtle and the tutorial makes sense and can stand without it.
+
+MailChimp publishes a style guide with recommendations on its voice and tone: http://styleguide.mailchimp.com/voice-and-tone/. Consider adopting these in your writing at Mapzen.
+
+Blog articles, however, usually display more personality than technical documentation. Consider writing a blog post if you want to go beyond standard technical documentation. You might write a blog in the first person, tell a personal anecdote, or use a funny video or image.
+
+## General guidelines
+
+- Write in a conversational and friendly tone that is also professional.
+- Use phrases and terms that are clear and easy to understand.
+- Avoid idioms or phrasing that is unfamiliar to the audience or would not translate to other languages directly.
+- Use active voice and avoid passive voice.
+- Address the audience as _you_ (second person. Avoid first person (I, we) and third person (the user, them). First person is acceptable in blogs or informal texts, but avoid it in technical documentation. Using _you_ also avoids the potential for gender-based terms, such as he or she.
+- It's okay to use contractions to create a more informal voice. Only use common contractions, though, such as _it's_ for _it is_ or _they're_ for _they are_. Don't make contractions with proper names or create unusual ones, such as _Mapzen'll_ for _Mapzen will..._ or _it'd_ for _it would_.
+- Use positive terms.
+- Avoid trite or overused phrases, including "Never fear!", "X is dead, long live X", "The future is...", and "Making a better world...". This also includes titles that are "clickbait" or vague. 
+
+Even though Mapzen may not formally translate documentation right now, there are many users who are outside the United States or speak languages other than English. The technical documentation should be easy to understand, and following these suggestions makes content easier to understand for all readers.
+
+## Code samples
+
+In command line code blocks, do not include the $ or other prompt text before what the reader needs to type. If you copy the code, you end up pasting extra text. The exception to this is if you are showing a series of commands and responses when including the $ is useful to show which lines are input.

--- a/src/site/guides/writing-style.md
+++ b/src/site/guides/writing-style.md
@@ -12,14 +12,14 @@ Blog articles, however, usually display more personality than technical document
 
 - Write in a conversational and friendly tone that is also professional.
 - Use phrases and terms that are clear and easy to understand.
-- Avoid idioms or phrasing that is unfamiliar to the audience or would not translate to other languages directly.
+- Avoid idioms, jargon, or phrasing that is unfamiliar to the audience or would not translate to other languages directly.
 - Use active voice and avoid passive voice.
 - Address the audience as _you_ (second person. Avoid first person (I, we) and third person (the user, them). First person is acceptable in blogs or informal texts, but avoid it in technical documentation. Using _you_ also avoids the potential for gender-based terms, such as he or she.
-- It's okay to use contractions to create a more informal voice. Only use common contractions, though, such as _it's_ for _it is_ or _they're_ for _they are_. Don't make contractions with proper names or create unusual ones, such as _Mapzen'll_ for _Mapzen will..._ or _it'd_ for _it would_.
-- Use positive terms.
-- Avoid trite or overused phrases, including "Never fear!", "X is dead, long live X", "The future is...", and "Making a better world...". This also includes titles that are "clickbait" or vague. 
+- Avoid contractions in technical documentation. It is okay to use them in less formal writing, such as a blog post. Only use common contractions, though, such as _it's_ for _it is_ or _they're_ for _they are_. Do not make contractions with proper names or create unusual ones, such as _Mapzen'll_ for _Mapzen will..._ or _it'd_ for _it would_.
+- Use positive terms rather than negative language.
+- Avoid trite or overused phrases, including "Never fear!", "X is dead, long live X", "The future is...", and "Making a better world...". This also includes titles that are vague or "clickbait."
 
-Even though Mapzen may not formally translate documentation right now, there are many users who are outside the United States or speak languages other than English. The technical documentation should be easy to understand, and following these suggestions makes content easier to understand for all readers.
+Even though Mapzen may not formally translate documentation, there are many users who are outside the United States or speak languages other than English. The technical documentation should be easy to understand, and following these suggestions makes content easier to understand for all readers.
 
 ## Code samples
 

--- a/src/site/guides/writing-style.md
+++ b/src/site/guides/writing-style.md
@@ -20,7 +20,3 @@ Blog articles, however, usually display more personality than technical document
 - Avoid trite or overused phrases, including "Never fear!", "X is dead, long live X", "The future is...", and "Making a better world...". This also includes titles that are vague or "clickbait."
 
 Even though Mapzen may not formally translate documentation, there are many users who are outside the United States or speak languages other than English. The technical documentation should be easy to understand, and following these suggestions makes content easier to understand for all readers.
-
-## Code samples
-
-In command line code blocks, do not include the $ or other prompt text before what the reader needs to type. If you copy the code, you end up pasting extra text. The exception to this is if you are showing a series of commands and responses when including the $ is useful to show which lines are input.


### PR DESCRIPTION
This includes some major updates to the writing/content style guidelines, which I haven't reviewed in a while. 
- file reorganization
- documentation for the build process, including adding redirects and renaming files
- reorganizing content and moving sections in files
- new info on voice and tone and product names

Right now, these files live buried in links, so we should find a way to highlight them into a table of contents (which is a separate issue from updating the content...see #308). https://mapzen.com/common/styleguide/resources.html
