### PR TITLE
Fix broken writing style links and reorder some of them

### DIFF
--- a/src/site/resources/content-guides/index.html
+++ b/src/site/resources/content-guides/index.html
@@ -1,14 +1,14 @@
 <div id="content-guides" class="headroom-large">
   <h5>Content Guides</h5>
   <p>
-    Below are some helpful links and pointers to writing content on mapzen.com.
+    Below are some helpful links and pointers to writing technical documentation and content on mapzen.com.
   </p>
   <ul>
-    <li><a href="https://github.com/mapzen/ui/blob/master/guides/common-terms-and-conventions.md"> Common terms and writing conventions</a></li>
-    <li><a href="https://github.com/mapzen/ui/blob/master/guides/doc-instructions.md"> Documentation authoring instructions </a></li>
-    <li><a href="https://github.com/mapzen/ui/blob/master/guides/maps.md"> Checklist for Maps</a></li>
-    <li><a href="https://github.com/mapzen/ui/blob/master/guides/tutorial-guidelines.md"> Guidelines for writing tutorials</a></li>
-    <li><a href="https://github.com/mapzen/ui/blob/master/guides/writing-style.md"> Voice and Tone</a></li>
-    <li><a href="https://github.com/mapzen/ui/blob/master/guides/github-waffle-integration.md"> Github+Waffle Integration</a></li>
+    <li><a href="https://github.com/mapzen/styleguide/blob/master/src/site/guides/common-terms-and-conventions.md"> Common terms and writing conventions</a></li>
+    <li><a href="https://github.com/mapzen/styleguide/blob/master/src/site/guides/tutorial-guidelines.md"> Guidelines for writing tutorials</a></li>
+    <li><a href="https://github.com/mapzen/styleguide/blob/master/src/site/guides/writing-style.md"> Voice and tone</a></li>
+    <li><a href="https://github.com/mapzen/styleguide/blob/master/src/site/guides/product-names.md"> Proper product names</a></li>
+    <li><a href="https://github.com/mapzen/styleguide/blob/master/src/site/guides/doc-instructions.md"> Documentation authoring instructions </a></li>
+    <li><a href="https://github.com/mapzen/styleguide/blob/master/src/site/guides/maps.md"> Checklist for Maps</a></li>
   </ul>
 </div>


### PR DESCRIPTION
The links on this page were still pointing to the deprecated UI repository.

Updated them to go to styleguide.

Also moved around some links. 

The GitHub/Waffle topic doesn't seem to belong here. The Maps list doesn't really either, but leaving it for now and moving to end.
