### PR TITLE
removed padding from editable input

### DIFF
--- a/src/stylesheets/project_specific/developer/_developer-dashboard.scss
+++ b/src/stylesheets/project_specific/developer/_developer-dashboard.scss
@@ -317,6 +317,11 @@
   }
 }
 
+.editable-input input {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
 .block-body{
   width:100%;
   height:100%;


### PR DESCRIPTION
- I thought we don't need specific styles for Editable (plugin we are using for inline editing) anymore, but it seems not. Removing padding to show the text correctly
  -closes https://github.com/mapzen/developer/issues/917
