### PR TITLE
Added option for a custom logout handler in MPZN.nav.reflectUserState()

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Please look at [Google Analytics page](https://support.google.com/analytics/answ
 
 | Method     | Return            | Description           |
 |------------|-------------------|---------|-----------------------|
-| `reflectUserState(<String> userNickname, <String> userAvatarImage)`      |`null`  | Manipulate navigation bar state with passed user data. To show not-logged-in status, pass `null` or empty string as parameters.    |
+| `reflectUserState(<String> userNickname, <String> userAvatarImage, [<Function> customLogoutCall])` |`null` | Manipulate navigation bar state with passed user data. To show not-logged-in status, pass `null` or empty string as parameters. Optionally provide a custom logout handler to override the default. |
 
 
 Contribute

--- a/dist/samples/blog-main.html
+++ b/dist/samples/blog-main.html
@@ -1584,6 +1584,14 @@
 <script src='../scripts/mapzen-styleguide.min.js'></script>
 <script>
   // Mimicking logged in status
-  MPZN.nav.reflectUserState('hanbyul-here','https://avatars.githubusercontent.com/u/4583806?v=3');
+  MPZN.nav.reflectUserState(
+    'hanbyul-here',
+    'https://avatars.githubusercontent.com/u/4583806?v=3',
+    function(e)
+    {
+        e.preventDefault();
+        e.stopPropagation();
+        alert("You asked to log out.");
+    });
 </script>
 </body></html>

--- a/src/scripts/main-nav.js
+++ b/src/scripts/main-nav.js
@@ -55,7 +55,7 @@
     developerRequest.send();
   }
 
-  function reflectUserState (nickname, imageurl) {
+  function reflectUserState (nickname, imageurl, customLogoutCall) {
 
     // // Send request to check the user is logged in or not
     // var developerRequest = new XMLHttpRequest();
@@ -68,7 +68,7 @@
       loginButton.parentNode.innerHTML = getLoginElem(nickname, imageurl);
       // After 'sign out element' in the dropdown was injected
       var signOutElem = document.querySelector('nav.navbar #sign-out');
-      signOutElem.addEventListener('click', makeLogoutCall);
+      signOutElem.addEventListener('click', customLogoutCall||makeLogoutCall);
       hideSignUpButton();
       putActiveTab();
     } else {


### PR DESCRIPTION
For Metro Extracts, we need to be able to override the built-in logout handler. An optional third argument to `MPZN.nav.reflectUserState` makes that possible.