### PR TITLE
issue template with workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ resources.
 
 ### MPZN
 
-These are Javascript APIs without UI components under MPZN name space. 
+These are Javascript APIs without UI components under MPZN name space.
 
 #### MPZN.trackevent
 `MPZN.trackevent`is a wrapper for customized Google Analytics event. You can initialize `MPZN.trackevent` with your own Google Analytics value. Google Anlyatics value is going to be sent with the initialization of `MPZN.trackevent`.
@@ -39,7 +39,7 @@ Please look at [Google Analytics page](https://support.google.com/analytics/answ
 
 #### MPZN.nav
 
-`MPZN.nav`is a read-only component dealing with user's log-in status on the navbar. 
+`MPZN.nav`is a read-only component dealing with user's log-in status on the navbar.
 
 | Method     | Return            | Description           |
 |------------|-------------------|---------|-----------------------|
@@ -57,6 +57,8 @@ To edit and test Styleguide, please work on a new branch in this repository and
 [use Precog](http://precog.mapzen.com/mapzen/styleguide) for preview and
 testing.
 
+To work with other Mapzen related-repo, please follow the steps in [contribution guide](https://github.com/mapzen/styleguide/blob/master/contribute.md#are-you-working-with-other-mapzen-related-repo). You can create an issue containing the check list with **[this link](https://github.com/mapzen/styleguide/issues/new?body=%23%23%23%20Are%20you%20working%20with%20other%20Mapzen-related%20repo%3F%20Please%20follow%20the%20steps%20below.%0A%0A%23%23%23%23%20pre-requirement%20%0A-%20%5B%20%5D%20Add%20temporary%20css%20or%20javascript%20on%20the%20branch%20of%20the%20repo%20which%20needs%20a%20change.%20%0A-%20%5B%20%5D%20Share%20changes%20with%20other%20people%20using%20Precog%0A%0A%23%23%23%23%20requirement%20%0A-%20%5B%20%5D%20Add%20new%20features%20on%20styleguide%20%0A-%20%5B%20%5D%20Reflect%20changes%20needed%20to%20the%20other%20repo%20you%20are%20working%20on%20%0A-%20%5B%20%5D%20Get%20rid%20of%20old%20features%20not%20used%20any%20more%20on%20Styleguide.%0A)**.
+
 🚧 `master` branch is live 🚧
 
 If you’d like to edit locally, Styleguide requires [Node](https://nodejs.org/)
@@ -67,6 +69,9 @@ sources in `src/site`. Build and test with these commands:
 2. `gulp build` (or `./node_modules/.bin/gulp build` if _gulp_ not found)
 3. `npm start`
 4. Open [http://localhost:3000](http://localhost:3000) in a browser.
+
+
+
 
 Organization
 ------------

--- a/contribute.md
+++ b/contribute.md
@@ -1,7 +1,6 @@
 Contribution Guide
 -----------------
 
-
 ### Image assets
 
 - SVG is preferred over JPG, PNG, SVG is recommended to be optimized through [SVGO](https://github.com/svg/svgo).
@@ -11,3 +10,17 @@ Contribution Guide
 
 - Users should be able to navigate the page only with keyboard.
 - Outlines of input forms shouldn't be disabled.
+
+### Are you working with other Mapzen-related repo?
+
+- When changes should happen across the repos, it is important to make each change not depending on each other. We recommend contributors to follow the steps below.
+
+#### Pre-requirement
+- Make an issue with checklist via [this link](https://github.com/mapzen/styleguide/issues/new?body=%23%23%23%20Are%20you%20working%20with%20other%20Mapzen-related%20repo%3F%20Please%20follow%20the%20steps%20below.%0A%0A%23%23%23%23%20pre-requirement%20%0A-%20%5B%20%5D%20Add%20temporary%20css%20or%20javascript%20on%20the%20branch%20of%20the%20repo%20which%20needs%20a%20change.%20%0A-%20%5B%20%5D%20Share%20changes%20with%20other%20people%20using%20Precog%0A%0A%23%23%23%23%20requirement%20%0A-%20%5B%20%5D%20Add%20new%20features%20on%20styleguide%20%0A-%20%5B%20%5D%20Reflect%20changes%20needed%20to%20the%20other%20repo%20you%20are%20working%20on%20%0A-%20%5B%20%5D%20Get%20rid%20of%20old%20features%20not%20used%20any%20more%20on%20Styleguide.%0A). Make the future issues and pr related to the task link to the issue.
+- Add temporary css or javascript on the branch of the repo which needs a change.
+- Share changes with other people using Precog.
+
+#### requirement
+- Add new features on styleguide.
+- Reflect changes needed to the other repo you are working on.
+- Get rid of old features not used any more on Styleguide.


### PR DESCRIPTION
- At first I thought I would just make issue template, then thought this template is needed for very specific people with specific purpose. So I added the link to generate issue template in `contribution.md`. I think this place makes sense, but if it is inconvenient for contributors to click on step deeper, we probably can put this on `index.md` as a section.
- Currently it has both change (make default issue template using`.github`folder and instruction on `contribution.md` I will delete one of them once we decide which one is better.
- Asking @rfriberg  for any thought :)