### PR TITLE
Scale heading tags for small screens

### DIFF
--- a/src/stylesheets/common/_typography.scss
+++ b/src/stylesheets/common/_typography.scss
@@ -10,41 +10,37 @@ body {
 
 // Headings
 
-h1 {
+h1, h2, h3 {
   font-weight: $bold-font-weight;
-  font-size: 48px;
-  // line-height: 1.2em;
-  // margin: 0px;
-  // color: $mz-red;
   margin-top: 48px;
   margin-bottom: 12px;
-  @media (min-width: $screen-sm) {
-    // font-size: 60px;
+  line-height: 1.2em;
+
+  // Scale back margins on mobile
+  @media (max-width: $screen-sm) {
+    margin-top: 24px;
+    margin-bottom: 6px;
   }
 }
 
+h1 {
+  font-size: 48px;
+  @media (max-width: $screen-sm) {
+    font-size: 42px;
+  }
+}
 
 h2 {
-  font-weight: $bold-font-weight;
   font-size: 36px;
-  // line-height: 1.2em;
-  margin-top: 48px;
-  margin-bottom: 12px;
-  @media (min-width: $screen-sm) {
-    // font-size: 48px;
+  @media (max-width: $screen-sm) {
+    font-size: 30px;
   }
 }
 
 h3 {
-  font-weight: $bold-font-weight;;
   font-size: 24px;
-  // line-height: 1.2em;
-  // margin: 0px;
-  // padding: 0px;
-  margin-top: 48px;
-  margin-bottom: 12px;
-  @media (min-width: $screen-sm) {
-    // font-size: 24px;
+  @media (max-width: $screen-sm) {
+    font-size: 18px;
   }
 }
 

--- a/src/stylesheets/project_specific/documentation/_base.scss
+++ b/src/stylesheets/project_specific/documentation/_base.scss
@@ -1,3 +1,13 @@
+
+// Special case for h1 on small screens
+h1 {
+  @media (max-width: $screen-sm) {
+    font-size: 36px;
+    margin-top: 12px;
+    margin-bottom: 0;
+  }
+}
+
 code, kbd, pre, samp {
   font-family: 'Source Code Pro', monospace;
 }


### PR DESCRIPTION
- Scale heading tags (font-size and margins) for small screens
- Shrink H1 even further for documentation page