### PR TITLE
Remove background color override from body

### DIFF
--- a/src/stylesheets/common/_general.scss
+++ b/src/stylesheets/common/_general.scss
@@ -6,7 +6,6 @@ html {
 body {
   font-family: $text-font-family;
   font-weight: $text-font-weight-regular;
-  background: transparent;
   overflow-x: hidden;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
Looks like we've been overriding the Bootstrap default body color since [a long long time ago](https://github.com/mapzen/website/commit/86a449c3fd0d6dd623ea215e211239b02b6d088f#diff-eb3ddf27d140f1c8604397ebc5c8d835R8).  I can't find a good reason for this (and someone finally noticed) so I'm proposing we remove the override.

 @hanbyul-here @louh @meghanhade  - let me know if you notice any pages that require a transparent background.  If so, we'll set those on a page-specific scss page.