### PR TITLE
CSS updates to mobile nav

### DIFF
--- a/dist/samples/accept-term.html
+++ b/dist/samples/accept-term.html
@@ -13,11 +13,11 @@
 <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-menu">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-menu">
         <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
+        <span class='icon-bar top-bar'></span>
+        <span class='icon-bar middle-bar'></span>
+        <span class='icon-bar bottom-bar'></span>
       </button>
       <a class="navbar-brand" href="/">
         <div class="mapzen-logo"></div>

--- a/dist/samples/blog-main-for-new-styleguide.html
+++ b/dist/samples/blog-main-for-new-styleguide.html
@@ -33,11 +33,11 @@
   <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
     <div class="container">
       <div class="navbar-header">
-        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-menu">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-menu">
           <span class="sr-only">Toggle navigation</span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
+          <span class='icon-bar top-bar'></span>
+          <span class='icon-bar middle-bar'></span>
+          <span class='icon-bar bottom-bar'></span>
         </button>
         <a class="navbar-brand" href="/">
           <div class="mapzen-logo"></div>

--- a/dist/samples/blog-main.html
+++ b/dist/samples/blog-main.html
@@ -33,11 +33,11 @@
   <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
     <div class="container">
       <div class="navbar-header">
-        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-menu">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-menu">
           <span class="sr-only">Toggle navigation</span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
+          <span class='icon-bar top-bar'></span>
+          <span class='icon-bar middle-bar'></span>
+          <span class='icon-bar bottom-bar'></span>
         </button>
         <a class="navbar-brand" href="/">
           <div class="mapzen-logo"></div>

--- a/dist/samples/blog-post.html
+++ b/dist/samples/blog-post.html
@@ -36,11 +36,11 @@
   <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
     <div class="container">
       <div class="navbar-header">
-        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-menu">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-menu">
           <span class="sr-only">Toggle navigation</span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
+          <span class='icon-bar top-bar'></span>
+          <span class='icon-bar middle-bar'></span>
+          <span class='icon-bar bottom-bar'></span>
         </button>
         <a class="navbar-brand" href="/">
           <div class="mapzen-logo"></div>

--- a/dist/samples/documentation.html
+++ b/dist/samples/documentation.html
@@ -19,11 +19,11 @@
   <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
     <div class="container">
       <div class="navbar-header">
-        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-menu">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-menu">
           <span class="sr-only">Toggle navigation</span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
+          <span class='icon-bar top-bar'></span>
+          <span class='icon-bar middle-bar'></span>
+          <span class='icon-bar bottom-bar'></span>
         </button>
         <a class="navbar-brand" href="/">
           <div class="mapzen-logo"></div>

--- a/dist/samples/projects-tangram.html
+++ b/dist/samples/projects-tangram.html
@@ -27,11 +27,11 @@
   <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
     <div class="container">
       <div class="navbar-header">
-        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-menu">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-menu">
           <span class="sr-only">Toggle navigation</span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
+          <span class='icon-bar top-bar'></span>
+          <span class='icon-bar middle-bar'></span>
+          <span class='icon-bar bottom-bar'></span>
         </button>
         <a class="navbar-brand" href="/">
           <div class="mapzen-logo"></div>

--- a/src/scripts/main-nav.js
+++ b/src/scripts/main-nav.js
@@ -160,7 +160,7 @@ function reflectUserState (id, nickname, imageurl, admin, customLogoutCall) {
 
   function getSignUpElem () {
     var strVar = '';
-    strVar += '<span class="visible-xs-inline visible-sm-inline visible-md-inline visible-lg-inline btn btn-white">';
+    strVar += '<span class="visible-xs-block visible-sm-inline visible-md-inline visible-lg-inline btn btn-white">';
     strVar += '  sign up';
     strVar += '<\/span>';
     return strVar;

--- a/src/site/fragments/global-nav.html
+++ b/src/site/fragments/global-nav.html
@@ -3,9 +3,9 @@
     <div class='navbar-header'>
       <button type='button' class='navbar-toggle' data-toggle='collapse' data-target='#navbar-menu'>
         <span class='sr-only'>Toggle navigation</span>
-        <span class='icon-bar'></span>
-        <span class='icon-bar'></span>
-        <span class='icon-bar'></span>
+        <span class='icon-bar top-bar'></span>
+        <span class='icon-bar middle-bar'></span>
+        <span class='icon-bar bottom-bar'></span>
       </button>
       <a class='navbar-brand' href='/'>
         <div class='mapzen-logo'></div>

--- a/src/stylesheets/common/_navbar.scss
+++ b/src/stylesheets/common/_navbar.scss
@@ -162,11 +162,12 @@ body.transparent-main-nav nav.navbar {
 // there is some more involved CSS overriding here
 .navbar-brand {
   // Match container edge
-  padding: 5px 30px 11px 15px;
+  padding: 9px 10px;
 
   // Branding size at tablet/desktop screen
   @media (min-width: $screen-sm) {
     height: 100%;
+    padding: 5px 30px 11px 15px;
 
     // When the navbar is forced to be full-width
     // of window, apply a padding on the left

--- a/src/stylesheets/common/_navbar.scss
+++ b/src/stylesheets/common/_navbar.scss
@@ -74,7 +74,7 @@ body {
 
     li {
       text-align: left;
-      border-top: 1px solid nth($mz-darkpurples, 5);
+      border-top: 1px solid nth($mz-darkpurples, 3);
     }
 
     li > a {
@@ -110,7 +110,7 @@ body {
   }
 
   .navbar-right {
-    border-top: 1px solid nth($mz-darkpurples, 5);
+    border-top: 1px solid nth($mz-darkpurples, 3);
 
     li {
       border-top: none;

--- a/src/stylesheets/common/_navbar.scss
+++ b/src/stylesheets/common/_navbar.scss
@@ -261,3 +261,42 @@ body.transparent-main-nav nav.navbar {
     text-align: left;
   }
 }
+
+// Hamburger to X animation
+.navbar-toggle {
+  .icon-bar {
+    width: 22px;
+    transition: all 0.2s;
+  }
+  .top-bar {
+    -webkit-transform: rotate(45deg);
+    -moz-transform: rotate(45deg);
+    transform: rotate(45deg);
+    -webkit-transform: 10% 10%;
+    -moz-transform: 10% 10%;
+    transform-origin: 10% 10%;
+  }
+  .middle-bar {
+    opacity: 0;
+  }
+  .bottom-bar {
+    -webkit-transform: rotate(-45deg);
+    -moz-transform: rotate(-45deg);
+    transform: rotate(-45deg);
+    -webkit-transform: 10% 90%;
+    -moz-transform: 10% 90%;
+    transform-origin: 10% 90%;
+  }
+
+  &.collapsed {
+    .top-bar,
+    .bottom-bar {
+     -webkit-transform: rotate(0);
+     -moz-transform: rotate(0);
+      transform: rotate(0);
+    }
+    .middle-bar {
+      opacity: 1;
+    }
+  }
+}

--- a/src/stylesheets/common/_navbar.scss
+++ b/src/stylesheets/common/_navbar.scss
@@ -72,10 +72,28 @@ body {
     margin-top: 0;
     margin-bottom: 0;
 
+    li {
+      text-align: left;
+      border-top: 1px solid nth($mz-darkpurples, 5);
+    }
+
     li > a {
       display: inline-block;
       background: transparent !important;
+      width: 100%;
     }
+  }
+
+  .navbar-right {
+    border-top: 1px solid nth($mz-darkpurples, 5);
+
+    li {
+      border-top: none;
+     }
+
+     #sign-up {
+      padding-top: 0;
+     }
   }
 }
 
@@ -103,12 +121,16 @@ body.transparent-main-nav nav.navbar {
 }
 
 
-
 .navbar-default .navbar-nav > .active > a,
 .navbar-default .navbar-nav > .active > a:hover,
 .navbar-default .navbar-nav > .active > a:focus {
   padding-bottom: 10px;
   border-bottom: 5px solid $navbar-active-link-color;
+
+  @media (max-width: $screen-xs-max) {
+    border-bottom: 0;
+    border-left: 5px solid $navbar-active-link-color;
+  }
 }
 
 // Navbar and branding size differs on mobile and tablet/desktop+, so

--- a/src/stylesheets/common/_navbar.scss
+++ b/src/stylesheets/common/_navbar.scss
@@ -82,6 +82,31 @@ body {
       background: transparent !important;
       width: 100%;
     }
+
+    // Open dropdown menu by default on mobile
+    .dropdown-menu {
+      position: static;
+      float: none;
+      width: auto;
+      margin-top: 0;
+      background-color: transparent;
+      border: 0;
+      box-shadow: none;
+      display: block;
+      > li > a,
+      .dropdown-header {
+        padding: 5px 15px 5px 25px;
+      }
+      > li > a {
+        line-height: $line-height-computed;
+        color: white;
+        &:hover,
+        &:focus {
+          background-image: none;
+        }
+      }
+    }
+
   }
 
   .navbar-right {


### PR DESCRIPTION
Update the look of the mobile nav per https://github.com/mapzen/website/issues/1472

Previews:
- Logged in: https://precog.mapzen.com/mapzen/styleguide/rfriberg/staging/mobile-nav/samples/blog-main.html 
- Not logged in: https://precog.mapzen.com/mapzen/styleguide/rfriberg/staging/mobile-nav/samples/documentation.html 

Some notes:
- Reordering the sign in / sign up will require a /website (and /developer and /styleguide) change.  I have a [WIP branch](https://github.com/mapzen/website/commit/81dd9ddebffcecaa4ac27b0fea3e254144f36e18) with these changes but the logged in dropdown looks a little lost at the top so want to wait until we sort out the best order for the mobile nav
- The active link (you can see it on that [second preview](https://precog.mapzen.com/mapzen/styleguide/rfriberg/staging/mobile-nav/samples/documentation.html)) looks more like a spacing issue than an indicator of what page you are on.  Maybe there's a better way to handle that highlight?

cc/ @souperneon 