### PR TITLE
Adjust vertical spacing around octocat; ensure vertical centering of tag

### DIFF
--- a/src/stylesheets/project_specific/developer/_developer-login.scss
+++ b/src/stylesheets/project_specific/developer/_developer-login.scss
@@ -113,18 +113,19 @@ $signupbtnh:45px;
   }
 }
 
-.octocat{
-  width: 200px;
-  height: 200px;
-  background-repeat:no-repeat;
-  background-position:center center;
+.octocat {
+  width: 180px;
+  height: 180px;
+  background-repeat: no-repeat;
+  background-position: center center;
   border-radius: 50%;
   background-size: 90% 90%;
   border: 1px solid #ccc;
   background-image: url(../images/octocat.png);
-  margin: 42px auto 42px auto;
-  &:hover{
-    background-image:url('//octodex.github.com/images/spidertocat.png');
+  margin: 26px auto;
+
+  &:hover {
+    background-image: url('https://octodex.github.com/images/spidertocat.png');
   }
 }
 
@@ -148,23 +149,27 @@ $signupbtnh:45px;
   float: right;
 }
 
-.separator {
+.column-separator {
   position: relative;
   margin-top: 50px;
-  height: 526px;
+  height: 400px;
   border-right: 1px solid nth($mz-darkpurples, 5);
 }
 
-.separator > .tag {
+.column-separator-tag {
   position: absolute;
   top: 50%;
   left: calc(100% - 33px);
+  margin-top: -32px;
+  width: 64px;
+  height: 64px;
+  line-height: 64px;
   font-size: 18px;
-  padding: 20px;
   font-weight: $text-font-weight-bold;
   border-radius: 50%;
   background-color: nth($mz-darkpurples, 5);
   text-transform: uppercase;
+  text-align: center;
 }
 
 .form-control[readonly] {
@@ -173,4 +178,3 @@ $signupbtnh:45px;
   box-shadow: none;
   border-bottom: 2px solid nth($mz-darkpurples, 2);
 }
-

--- a/src/stylesheets/project_specific/developer/_developer-login.scss
+++ b/src/stylesheets/project_specific/developer/_developer-login.scss
@@ -122,7 +122,7 @@ $signupbtnh:45px;
   background-size: 90% 90%;
   border: 1px solid #ccc;
   background-image: url(../images/octocat.png);
-  margin: 26px auto;
+  margin: 34px auto;
 
   &:hover {
     background-image: url('https://octodex.github.com/images/spidertocat.png');


### PR DESCRIPTION
This PR adjusts styling of design elements on the sign-in/sign-up pages:

- the "or" tag is guaranteed to be in the middle of the separator line. Its width and height are fixed numbers so that it does not vary with font-size.
- the Octocat image is slightly smaller, allowing the GitHub button to line up again with the sign-in button.
- the separator can be smaller in height.
- finally, this uses the new namespaced class names for `separator` and `tag` to reduce the chance of class name collisions.

Please merge only after https://github.com/mapzen/developer/pull/1230 is accepted. cc @sleepylemur 

