### PR TITLE
Revise buttons (a proposal)

### DIFF
--- a/src/site/design-elements/buttons/index.html
+++ b/src/site/design-elements/buttons/index.html
@@ -1,26 +1,43 @@
 <div id="buttons" class="headroom-large">
   <h2>Buttons</h2>
+
   <p>This is the primary button style for important calls to action. Two primary buttons cannot be used next to each other.</p>
+  <div class="alert alert-info" role="alert">The `.btn-primary` class replaces the old `.btn-mapzen` class, which is now deprecated.</div>
   <div data-xrayhtml>
-    <button class="btn btn-mapzen">primary button</button>
+    <button class="btn btn-primary">Primary button</button>
   </div>
-  <div data-xrayhtml>
-    <button class="btn btn-secondary">secondary button</button>
-  </div>
+
   <p>This is the secondary button style. Used next to a primary style if there are two buttons next to each other.</p>
-  <div data-xrayhtml class="mz-darkpurples1">
-    <button class="btn btn-inverse">inverse button</button>
-  </div>
-  <p>This is the inverse button style. Use it on non-white backgrounds.</p>
   <div data-xrayhtml>
-    <div class="btn-group">
-      <button class="btn btn-mapzen"> Button One</button>
-      <button class="btn btn-secondary">Button Two</button>
-      <button class="btn btn-secondary"> Button Three</button>
-    </div>
+    <button class="btn btn-secondary">Secondary button</button>
   </div>
+
+  <p>This is the inverse button style. Use it on non-white backgrounds.</p>
+  <div data-xrayhtml class="mz-darkpurples1">
+    <button class="btn btn-inverse">Inverse button</button>
+  </div>
+
+  <p>If a button should be full-width on mobile, add the <code>.btn-flexible</code> class.</p>
+  <div data-xrayhtml>
+    <button class="btn btn-primary btn-flexible">Flexible button</button>
+  </div>
+
+  <p>A series of buttons can be placed next to each other, and spacing will be applied. This works for buttons that are in line as well as flexible buttons that will be stacked vertically on mobile.</p>
+  <div data-xrayhtml>
+    <button class="btn btn-primary btn-flexible">Button one</button>
+    <button class="btn btn-secondary btn-flexible">Button two</button>
+    <button class="btn btn-secondary btn-flexible">Button three</button>
+  </div>
+
   <p>This style is used for calls to action after paragraphs of text and draws less attention than a proper button.</p>
   <div data-xrayhtml>
-    <button class="btn btn-with-arrow">no chrome button</button>
+    <button class="btn btn-with-arrow">Learn more</button>
+  </div>
+
+  <p>Buttons require JavaScript to handle clicks and perform actions. If you are just using a button to link to another page, use an anchor tag.</p>
+  <div data-xrayhtml>
+    <a class="btn btn-primary" href="#buttons">Primary button</a>
+    <a class="btn btn-secondary" href="#buttons">Secondary button</a>
+    <a class="btn btn-with-arrow" href="#buttons">Learn more button</a>
   </div>
 </div>

--- a/src/stylesheets/common/_buttons.scss
+++ b/src/stylesheets/common/_buttons.scss
@@ -31,7 +31,7 @@ input[type="search"] + .btn {
 
   &:hover,
   &:focus {
-    background-color: $mz-darkpurple-1;
+    background-color: $mz-darkpurple-2;
     color: white;
   }
 }

--- a/src/stylesheets/common/_buttons.scss
+++ b/src/stylesheets/common/_buttons.scss
@@ -22,12 +22,17 @@ input[type="search"] + .btn {
 
 // Dark purple button
 .btn-mapzen {
-  background-color: nth($mz-darkpurples, 1);
-  color: #ffffff;
+  @extend .btn-primary;
+}
+
+.btn-primary {
+  background-color: $mz-darkpurple-1;
+  color: white;
+
   &:hover,
   &:focus {
-    background-color: nth($mz-darkpurples, 2);
-    color: #ffffff;
+    background-color: $mz-darkpurple-1;
+    color: white;
   }
 }
 
@@ -40,7 +45,6 @@ input[type="search"] + .btn {
     color: nth($mz-darkpurples, 1);
   }
 }
-
 
 // To be deprecated in favor of btn-inverse
 .btn-white {
@@ -122,15 +126,9 @@ input[type="search"] + .btn {
   }
 }
 
-.btn-flexible {
-  width: 100%;
-  @media (min-width: $screen-sm) {
-    width: auto;
-  }
-}
-
 // Button groups
-// Giving margin-right to the buttons
+// Giving margin-right to the buttons. This overrides Bootstrap's default look
+// for button groups, which creates buttons that are visually connected to each other.
 .btn-group .btn {
   margin-right: 10px;
   margin-bottom: 10px;
@@ -139,4 +137,28 @@ input[type="search"] + .btn {
 // Undo the overall bottom margin
 .btn-group {
   margin-bottom: -10px;
+}
+
+// NOTE: This should be the preferred way to ensure buttons are spaced correctly.
+.btn + .btn {
+  margin-left: 10px;
+}
+
+.btn-flexible {
+  width: 100%;
+
+  // Ensure adequate vertical spacing between consecutive block buttons.
+  & + .btn-flexible {
+    margin-top: 12px;
+    margin-left: 0;
+  }
+
+  @media (min-width: $screen-sm) {
+    width: auto;
+
+    & + .btn-flexible {
+      margin-top: auto;
+      margin-left: 10px;
+    }
+  }
 }


### PR DESCRIPTION
There are a few things in here related to button styles, and documentation of these styles.

## Code

- Buttons are now automatically given the correct side margins when placed next to each other, and do not require wrapping in `.btn-group` to do so. (Note that `.btn-group` has a specific meaning and appearance in stock Bootstrap, so reading Bootstrap documentation to understand its use in Mapzen styleguide was not fruitful.) See #416.
- Buttons are also given the correct top margins when placed below each other (via `.btn-flexible`).
- The `.btn-mapzen` class is deprecated and replaced with `.btn-primary`. Its behavior is exactly the same. For backwards compatibility, `.btn-mapzen` continues to exist and is aliased to `.btn-primary`. This has triggered some discussion about what "Primary" means on different colored backgrounds, but I believe this is outside the scope of this PR; I presume that stacking `.btn-inverse` on `.btn-primary` has the intended effect, but have not tested this.

## Documentation

- Text descriptions were inconsistently placed below code snippets. These descriptions have been moved above code snippets, matching how this appears throughout the rest of this page.
- The `.btn-flexible` class was missing. This is now added.
- We needed to make clear that all `.btn-*` classes may also be applied to `<a>` tags and not just `<button>`s, because when buttons are actually links this is the preferred syntax.
