### PR TITLE
btn-primary defined with Bootstrap

### DIFF
--- a/src/stylesheets/common/_buttons.scss
+++ b/src/stylesheets/common/_buttons.scss
@@ -26,13 +26,10 @@ input[type="search"] + .btn {
 }
 
 .btn-primary {
-  background-color: $mz-darkpurple-1;
-  color: white;
-
+  // Inherits from Bootstrap
   &:hover,
   &:focus {
     background-color: $mz-darkpurple-2;
-    color: white;
   }
 }
 

--- a/src/stylesheets/common/_variables.scss
+++ b/src/stylesheets/common/_variables.scss
@@ -74,6 +74,9 @@ $breadcrumb-separator: "\f105";
 // Tables
 $table-bg-hover: transparent;
 
+// Buttons
+$btn-primary-bg: $mz-darkpurple-1;
+
 
 // MAPZEN-SPECIFIC SITE VARIABLES
 // --------------------------------------------------


### PR DESCRIPTION
Whoops! This is what happens when you try to revert to Bootstrap syntax where possible but forget to redefine the variables Bootstrap uses! We needed to tell Bootstrap to use our colors for their components.
