### PR TITLE
Add spacing utility classes from bootstrap-4-dev

### DIFF
--- a/src/stylesheets/common/_spacing.scss
+++ b/src/stylesheets/common/_spacing.scss
@@ -1,0 +1,58 @@
+// Spacing utility classes
+// Adapted from Bootstrap v4.0.0-dev (4/25/17)
+// --------------------------------------
+
+
+// Grid breakpoints
+
+$grid-breakpoints: (
+  xs: 0,
+  sm: $screen-sm-min,
+  md: $screen-md-min,
+  lg: $screen-lg-min
+) !default;
+
+// Margin and Padding
+//
+//  - margin: m{sides}-{size}
+//  - padding: p{sides}-{size}
+
+@each $breakpoint in map-keys($grid-breakpoints) {
+  @include media-breakpoint-up($breakpoint) {
+    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+
+    @each $prop, $abbrev in (margin: m, padding: p) {
+      @each $size, $length in $spacers {
+
+        .#{$abbrev}#{$infix}-#{$size}  { #{$prop}:        $length !important; }
+        .#{$abbrev}t#{$infix}-#{$size} { #{$prop}-top:    $length !important; }
+        .#{$abbrev}r#{$infix}-#{$size} { #{$prop}-right:  $length !important; }
+        .#{$abbrev}b#{$infix}-#{$size} { #{$prop}-bottom: $length !important; }
+        .#{$abbrev}l#{$infix}-#{$size} { #{$prop}-left:   $length !important; }
+        .#{$abbrev}x#{$infix}-#{$size} {
+          #{$prop}-right: $length !important;
+          #{$prop}-left:  $length !important;
+        }
+        .#{$abbrev}y#{$infix}-#{$size} {
+          #{$prop}-top:    $length !important;
+          #{$prop}-bottom: $length !important;
+        }
+      }
+    }
+
+    // Some special margin utils
+    .m#{$infix}-auto  { margin:        auto !important; }
+    .mt#{$infix}-auto { margin-top:    auto !important; }
+    .mr#{$infix}-auto { margin-right:  auto !important; }
+    .mb#{$infix}-auto { margin-bottom: auto !important; }
+    .ml#{$infix}-auto { margin-left:   auto !important; }
+    .mx#{$infix}-auto {
+      margin-right: auto !important;
+      margin-left:  auto !important;
+    }
+    .my#{$infix}-auto {
+      margin-top:    auto !important;
+      margin-bottom: auto !important;
+    }
+  }
+}

--- a/src/stylesheets/common/_variables.scss
+++ b/src/stylesheets/common/_variables.scss
@@ -77,6 +77,22 @@ $table-bg-hover: transparent;
 // Buttons
 $btn-primary-bg: $mz-darkpurple-1;
 
+// Spacing
+//
+// Control the default styling of most Bootstrap elements by modifying these
+// variables. Mostly focused on spacing.
+// You can add more entries to the $spacers map, should you need more variation.
+
+$spacer: 24px !default;
+$spacers: (
+  0: 0,
+  1: ($spacer * .25),
+  2: ($spacer * .5),
+  3: $spacer,
+  4: ($spacer * 1.5),
+  5: ($spacer * 3)
+) !default;
+
 
 // MAPZEN-SPECIFIC SITE VARIABLES
 // --------------------------------------------------

--- a/src/stylesheets/common/mixins/_breakpoints.scss
+++ b/src/stylesheets/common/mixins/_breakpoints.scss
@@ -1,0 +1,35 @@
+// Breakpoint viewport sizes and media queries.
+//
+// Breakpoints are defined as a map of (name: minimum width), order from small to large:
+//
+//    (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px)
+//
+// The map defined in the `$grid-breakpoints` global variable is used as the `$breakpoints` argument by default.
+
+// Minimum breakpoint width. Null for the smallest (first) breakpoint.
+//
+//    >> breakpoint-min(sm, (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px))
+//    576px
+@function breakpoint-min($name, $breakpoints: $grid-breakpoints) {
+  $min: map-get($breakpoints, $name);
+  @return if($min != 0, $min, null);
+}
+
+// Media of at least the minimum breakpoint width. No query for the smallest breakpoint.
+// Makes the @content apply to the given breakpoint and wider.
+@mixin media-breakpoint-up($name, $breakpoints: $grid-breakpoints) {
+  $min: breakpoint-min($name, $breakpoints);
+  @if $min {
+    @media (min-width: $min) {
+      @content;
+    }
+  } @else {
+    @content;
+  }
+} 
+
+// Returns a blank string if smallest breakpoint, otherwise returns the name with a dash infront.
+// Useful for making responsive utilities.
+@function breakpoint-infix($name, $breakpoints: $grid-breakpoints) {
+  @return if(breakpoint-min($name, $breakpoints) == null, "", "-#{$name}");
+}

--- a/src/stylesheets/styleguide.scss
+++ b/src/stylesheets/styleguide.scss
@@ -6,6 +6,9 @@
 
 @import 'bootstrap-custom';
 
+// Mapzen mixins
+@import "common/mixins/breakpoints";
+
 // Mapzen site specific
 @import 'common/admonition';
 @import 'common/alerts';
@@ -42,6 +45,7 @@
 @import 'common/search';
 @import 'common/section-nav';
 @import 'common/social';
+@import 'common/spacing';
 @import 'common/tables';
 @import 'common/toc';
 @import 'common/typography';


### PR DESCRIPTION
This adds all spacing utility classes from the latest Bootstrap v4-dev.  (At this point, the format of the classnames should not be changing prior to v4 launch.)

It does add 60kb to the compiled `styleguide.css`.  I could reduce this by taking out the responsive classes, but want to get opinions from everyone on what would be most helpful.

Here are some example classes, if you want to understand better how these work.  The basic format is `m{sides}-{size}` and `m{sides]-{breakpoint}-{size}` for margins and `p{sides}-{size}` and `p{sides]-{breakpoint}-{size}` for padding.

Basic:
```
.mt-0 {
  margin-top: 0 !important; }

.mr-0 {
  margin-right: 0 !important; }

.px-2 {
  padding-right: 12px !important;
  padding-left: 12px !important; }

.py-2 {
  padding-top: 12px !important;
  padding-bottom: 12px !important; }
```

Responsive:
```
@media (min-width: 768px) {
  .m-sm-0 {
    margin: 0 !important; }
  .mt-sm-1 {
    margin-top: 6px !important; }
  .pr-sm-2 {
    padding-right: 12px !important; }
  .pb-sm-3 {
    padding-bottom: 24px !important; }
}
```