### PR TITLE
Remove broken SVGs

### DIFF
--- a/src/stylesheets/common/_forms.scss
+++ b/src/stylesheets/common/_forms.scss
@@ -184,9 +184,6 @@ input[type="checkbox"]:hover + *:before {
 input[type="checkbox"]:checked + *:before {
   background-image: url(data:image/svg+xml,%3Csvg%20data-name%3D%27Layer%201%27%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%2036%2036%27%3E%3Ctitle%3Echeckbox-checked%3C/title%3E%3Cpath%20fill%3D%27%232C1E3F%27%20d%3D%27M0%200h36v36H0z%27/%3E%3Cpath%20fill%3D%27none%27%20stroke%3D%27%23fff%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%20stroke-width%3D%274.252%27%20d%3D%27M26.19%2011.16l-9.17%2013.68-7.21-5.22%27/%3E%3C/svg%3E);
 }
-input[type="checkbox"]:checked:hover + *:before {
-  background-image: url(data:image/svg+xml,%3Csvg%20data-name%3D%27Layer%201%27%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%2036%2036%27%3E%3Ctitle%3Echeckbox-focused%3C/title%3E%3Cpath%20fill%3D%27%21E0E33e%27%20d%3D%27M0%200h36v36H0z%27/%3E%3Cpath%20fill%3D%27none%27%20stroke%3D%27%23fff%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%20stroke-width%3D%274.252%27%20d%3D%27M26.19%2011.16l-9.17%2013.68-7.21-5.22%27/%3E%3C/svg%3E);
-}
 
 input[type="radio"] + *:before {
   background-image: url(data:image/svg+xml,%3Csvg%20id%3D%27Layer_1%27%20data-name%3D%27Layer%201%27%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%2035%2035%27%3E%3Ctitle%3EUntitled-5%3C/title%3E%3Cpath%20d%3D%27M18%2C4.75A13.25%2C13.25%2C0%2C1%2C1%2C4.75%2C18%2C13.26%2C13.26%2C0%2C0%2C1%2C18%2C4.75M18%2C0.5A17.5%2C17.5%2C0%2C1%2C0%2C35.5%2C18%2C17.5%2C17.5%2C0%2C0%2C0%2C18%2C.5h0Z%27%20transform%3D%27translate%28-0.5%20-0.5%29%27%20style%3D%27fill%3A%23cdcccc%27/%3E%3C/svg%3E);
@@ -198,9 +195,7 @@ input[type="radio"]:hover + *:before {
 input[type="radio"]:checked + *:before {
   background-image: url(data:image/svg+xml,%3Csvg%20id%3D%27Layer_1%27%20data-name%3D%27Layer%201%27%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%2035%2035%27%3E%3Ctitle%3EUntitled-7%3C/title%3E%3Cpath%20d%3D%27M18%2C4.75A13.25%2C13.25%2C0%2C1%2C1%2C4.75%2C18%2C13.26%2C13.26%2C0%2C0%2C1%2C18%2C4.75M18%2C0.5A17.5%2C17.5%2C0%2C1%2C0%2C35.5%2C18%2C17.5%2C17.5%2C0%2C0%2C0%2C18%2C.5h0Z%27%20transform%3D%27translate%28-0.5%20-0.5%29%27%20style%3D%27fill%3A%232C1E3F%27/%3E%3Ccircle%20cx%3D%2717.5%27%20cy%3D%2717.5%27%20r%3D%279%27%20style%3D%27fill%3A%232C1E3F%27/%3E%3C/svg%3E);
 }
-input[type="radio"]:checked:hover + *:before {
-  background-image: url(data:image/svg+xml,%3Csvg%20id%3D%27Layer_1%27%20data-name%3D%27Layer%201%27%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%2034.97%2034.97%27%3E%3Cdefs%3E%3Cstyle%3E.cls-1%7Bfill%3A%21E0E33e%3B%7D%3C/style%3E%3C/defs%3E%3Ctitle%3EUntitled-8%3C/title%3E%3Cpath%20class%3D%27cls-1%27%20d%3D%27M19%2C5.77A13.23%2C13.23%2C0%2C1%2C1%2C5.77%2C19%2C13.25%2C13.25%2C0%2C0%2C1%2C19%2C5.77m0-4.25A17.48%2C17.48%2C0%2C1%2C0%2C36.49%2C19%2C17.48%2C17.48%2C0%2C0%2C0%2C19%2C1.51h0Z%27%20transform%3D%27translate%28-1.51%20-1.51%29%27/%3E%3Ccircle%20class%3D%27cls-1%27%20cx%3D%2717.49%27%20cy%3D%2717.48%27%20r%3D%279%27/%3E%3C/svg%3E);
-}
+
 input[type="range"] {
   -webkit-appearance: none;
   cursor: pointer;


### PR DESCRIPTION
We had one more particularly weird CSS error (blocking #466) that took me a while to track down. Here's the story.

Inside of `_forms.scss` we have an image for radio inputs and checkboxes that are in a checked + hover state. However (and you can double check them on the styleguide here: https://mapzen.com/common/styleguide/design-elements.html#forms) these hovered states do not work properly. It's very subtle, but the hover state is actually black instead of dark purple.

If we examine the SVG data-URI, it would be the equivalent of this string:

```
<svg data-name='Layer 1' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36'><title>checkbox-focused</title><path fill='!E0E33e' d='M0 0h36v36H0z'/><path fill='none' stroke='#fff' stroke-linecap='round' stroke-linejoin='round' stroke-width='4.252' d='M26.19 11.16l-9.17 13.68-7.21-5.22'/></svg>
```

The problem lies in `path fill='!E0E33e'`, which mistakenly uses a `!` instead of a `#` for a hex color. This was making the CSS minifier very unhappy. (I don't think it's the minifier's business to parse data-URIs, but that's a separate conversation.)

If it were formatted properly, the hovered checkbox state would be this version of yellow instead of black:

![screenshot 2017-04-28 11 36 04](https://cloud.githubusercontent.com/assets/2553268/25535963/e3358ae6-2c06-11e7-8bd5-8a6dc6cb42e5.png)

Upon reviewing with @souperneon we decided that if it didn't work before, it doesn't need to work now, especially since this yellow is not really used anywhere else. So we can fix the minifier issue just by removing the offending data-URIs from the styleguide.
