### PR TITLE
Meghan/master/header class#463

### DIFF
--- a/src/stylesheets/common/_documentation.scss
+++ b/src/stylesheets/common/_documentation.scss
@@ -8,7 +8,7 @@
   justify-content: center;
   padding: 40px 20px;
   .documentation-header{
-    /* from styleguide _documentation.scss h1*/
+    /* copying _documentation.scss style for h1*/
     position: relative;
     font-weight: 700;
     font-family: "Poppins", "Open Sans", Helvetica, Arial, sans-serif;
@@ -90,6 +90,16 @@
   // Headings
   h1, h2, h3, h4, h5, h6 {
     position: relative;
+  }
+
+  /*smaller for documentation than styleguide*/
+  h1 {
+    font-size: 36px;
+  }
+
+  /*smaller for documentation than styleguide*/
+  h2 {
+    font-size: 24px;
   }
 
   /*

--- a/src/stylesheets/common/_documentation.scss
+++ b/src/stylesheets/common/_documentation.scss
@@ -7,8 +7,14 @@
   align-items: center;
   justify-content: center;
   padding: 40px 20px;
+  h1 {
+    
+  }
   .documentation-header{
-    /* copying _documentation.scss style for h1*/
+    /*former .documentation-hero h1 style*/
+    padding-top: 20px;
+    color: #fff;
+    /* _documentation.scss style for h1*/
     position: relative;
     font-weight: 700;
     font-family: "Poppins", "Open Sans", Helvetica, Arial, sans-serif;

--- a/src/stylesheets/common/_documentation.scss
+++ b/src/stylesheets/common/_documentation.scss
@@ -7,18 +7,17 @@
   align-items: center;
   justify-content: center;
   padding: 40px 20px;
-
-  documentation-header {
-    padding-top: 20px;
-    color: #fff;
-    
-    /*mimics h1 style*/
+  .documentation-header{
+    /* from styleguide _documentation.scss h1*/
+    position: relative;
+    font-weight: 700;
+    font-family: "Poppins", "Open Sans", Helvetica, Arial, sans-serif;
+    /* from styleguide _typography.scss */
+    font-size: 48px;
     margin-top: 48px;
     margin-bottom: 12px;
     line-height: 1.2em;
-    font-size: 48px;
-    
-    /*Scale back margins on mobile*/
+    /* scale back margins on mobile */
     @media (max-width: $screen-sm) {
       font-size: 42px;
       margin-top: 24px;

--- a/src/stylesheets/common/_documentation.scss
+++ b/src/stylesheets/common/_documentation.scss
@@ -10,24 +10,19 @@
   h1 {
     
   }
-  .documentation-header{
-    /*former .documentation-hero h1 style*/
+  .documentation-header {
+    /* former _documentation.scss documentation-hero h1*/
     padding-top: 20px;
     color: #fff;
-    /* _documentation.scss style for h1*/
-    position: relative;
-    font-weight: 700;
-    font-family: "Poppins", "Open Sans", Helvetica, Arial, sans-serif;
-    /* from styleguide _typography.scss */
+    /* former _documentation.scss h1*/
+    font-weight: $display-font-weight-bold;
+    font-family: $display-font-family;
+    /* former _typography.scss */
     font-size: 48px;
-    margin-top: 48px;
-    margin-bottom: 12px;
     line-height: 1.2em;
     /* scale back margins on mobile */
     @media (max-width: $screen-sm) {
       font-size: 42px;
-      margin-top: 24px;
-      margin-bottom: 6px;
     }
   }
   p {
@@ -106,6 +101,11 @@
   /*smaller for documentation than styleguide*/
   h2 {
     font-size: 24px;
+  }
+
+  /*smaller for documentation than styleguide*/
+  h3 {
+    font-size: 20px;
   }
 
   /*

--- a/src/stylesheets/common/_documentation.scss
+++ b/src/stylesheets/common/_documentation.scss
@@ -8,11 +8,23 @@
   justify-content: center;
   padding: 40px 20px;
 
-  h1 {
+  documentation-header {
     padding-top: 20px;
     color: #fff;
+    
+    /*mimics h1 style*/
+    margin-top: 48px;
+    margin-bottom: 12px;
+    line-height: 1.2em;
+    font-size: 48px;
+    
+    /*Scale back margins on mobile*/
+    @media (max-width: $screen-sm) {
+      font-size: 42px;
+      margin-top: 24px;
+      margin-bottom: 6px;
+    }
   }
-
   p {
     margin-top: 24px;//1em;
   }


### PR DESCRIPTION
Adds documentation-header class to replace h1 used previously. Reduces size of h1 and h2 in documentation.

Closes #463 