### PR TITLE
Enable bootstrap progress bars

### DIFF
--- a/src/stylesheets/_bootstrap-custom.scss
+++ b/src/stylesheets/_bootstrap-custom.scss
@@ -31,7 +31,7 @@
 //@import "bootstrap/jumbotron";
 //@import "bootstrap/thumbnails";
 //@import "bootstrap/alerts";
-//@import "bootstrap/progress-bars";
+@import "bootstrap/progress-bars";
 //@import "bootstrap/media";
 //@import "bootstrap/list-group";
 @import "bootstrap/panels";


### PR DESCRIPTION
Enable bootstrap progress bars for use on developer dashboard.

(Adds 2KB to minified styleguide.min.css)