### PR TITLE
Update colors

### DIFF
--- a/src/site/design-elements/colors/index.html
+++ b/src/site/design-elements/colors/index.html
@@ -3,9 +3,9 @@
   <div>
     <p class="headroom">Below is the full Mapzen color palette. Dark purples and scarlets are the most visible on the website and the pinks and purples play a supportive role to add some pop in when necessary.</p>
 
-    <div>
+    <div class="container-fluid">
       <div class="row">
-        <div class="col-xs-3 color-swatch mz-darkpurples1">
+        <div class="col-xs-4 color-swatch mz-darkpurple-1">
           <h4>Dark Purple 1</h4>
           <div class="color-swatch-value">
             <p>#1e0e33</p>
@@ -15,7 +15,7 @@
             <p>$mz-darkpurple-1</p>
           </div>
         </div>
-        <div class="col-xs-3 color-swatch mz-darkpurples2">
+        <div class="col-xs-4 color-swatch mz-darkpurple-2">
           <h4>Dark Purple 2</h4>
           <div class="color-swatch-value">
             <p>#2c1e3f</p>
@@ -25,7 +25,7 @@
             <p>$mz-darkpurple-2</p>
           </div>
         </div>
-        <div class="col-xs-3 color-swatch mz-darkpurples3">
+        <div class="col-xs-4 color-swatch mz-darkpurple-3">
           <h4>Dark Purple 3</h4>
           <div class="color-swatch-value">
             <p>#635378</p>
@@ -35,7 +35,9 @@
             <p>$mz-darkpurple-3</p>
           </div>
         </div>
-        <div class="col-xs-3 color-swatch mz-darkpurples4">
+      </div>
+      <div class="row">
+        <div class="col-xs-4 color-swatch mz-darkpurple-4">
           <h4>Dark Purple 4</h4>
           <div class="color-swatch-value">
             <p>#ad9cc2</p>
@@ -45,9 +47,19 @@
             <p>$mz-darkpurple-4</p>
           </div>
         </div>
+        <div class="col-xs-4 color-swatch color-swatch-inverse mz-darkpurple-5">
+          <h4>Dark Purple 5</h4>
+          <div class="color-swatch-value">
+            <p>#eee7f8</p>
+            <p>rgb(238, 231, 248)</p>
+          </div>
+          <div class="color-swatch-name">
+            <p>$mz-darkpurple-5</p>
+          </div>
+        </div>
       </div>
       <div class="row">
-        <div class="col-xs-3 color-swatch mz-scarlets1">
+        <div class="col-xs-4 color-swatch mz-scarlet-1">
           <h4>Scarlet 1</h4>
           <div class="color-swatch-value">
             <p>#ff4947</p>
@@ -57,7 +69,7 @@
             <p>$mz-scarlet-1</p>
           </div>
         </div>
-        <div class="col-xs-3 color-swatch mz-scarlets2">
+        <div class="col-xs-4 color-swatch mz-scarlet-2">
           <h4>Scarlet 2</h4>
           <div class="color-swatch-value">
             <p>#ff7b7b</p>
@@ -67,7 +79,7 @@
             <p>$mz-scarlet-2</p>
           </div>
         </div>
-        <div class="col-xs-3 color-swatch color-swatch-inverse mz-scarlets3">
+        <div class="col-xs-4 color-swatch color-swatch-inverse mz-scarlet-3">
           <h4>Scarlet 3</h4>
           <div class="color-swatch-value">
             <p>#fcdbdb</p>
@@ -79,7 +91,7 @@
         </div>
       </div>
       <div class="row">
-        <div class="col-xs-3 color-swatch mz-pinks1">
+        <div class="col-xs-4 color-swatch mz-pink-1">
           <h4>Pink 1</h4>
           <div class="color-swatch-value">
             <p>#f9a293</p>
@@ -89,7 +101,7 @@
             <p>$mz-pink-1</p>
           </div>
         </div>
-        <div class="col-xs-3 color-swatch color-swatch-inverse mz-pinks2">
+        <div class="col-xs-4 color-swatch color-swatch-inverse mz-pink-2">
           <h4>Pink 2</h4>
           <div class="color-swatch-value">
             <p>#f7beb4</p>
@@ -99,7 +111,7 @@
             <p>$mz-pink-2</p>
           </div>
         </div>
-        <div class="col-xs-3 color-swatch color-swatch-inverse mz-pinks3">
+        <div class="col-xs-4 color-swatch color-swatch-inverse mz-pink-3">
           <h4>Pink 3</h4>
           <div class="color-swatch-value">
             <p>#fbe6e3</p>
@@ -111,7 +123,7 @@
         </div>
       </div>
       <div class="row">
-        <div class="col-xs-3 color-swatch mz-purples1">
+        <div class="col-xs-4 color-swatch mz-purple-1">
           <h4>Purple 1</h4>
           <div class="color-swatch-value">
             <p>#7f2de3</p>
@@ -121,7 +133,7 @@
             <p>$mz-purple-1</p>
           </div>
         </div>
-        <div class="col-xs-3 color-swatch mz-purples2">
+        <div class="col-xs-4 color-swatch mz-purple-2">
           <h4>Purple 2</h4>
           <div class="color-swatch-value">
             <p>#985fdd</p>
@@ -131,7 +143,7 @@
             <p>$mz-purple-2</p>
           </div>
         </div>
-        <div class="col-xs-3 color-swatch mz-purples3">
+        <div class="col-xs-4 color-swatch mz-purple-3">
           <h4>Purple 3</h4>
           <div class="color-swatch-value">
             <p>#bda2dd</p>
@@ -147,7 +159,9 @@
 
   <div>
     <p class="headroom">Tertiary colors complement the main palette and are used for text, inactive states and borders.</p>
-    <div class="row">
+
+    <div class="container-fluid">
+      <div class="row">
       <div class="col-xs-3 color-swatch mz-black">
         <h4>Off Black</h4>
         <div class="color-swatch-value">
@@ -188,6 +202,7 @@
           <p>$mz-lightgray</p>
         </div>
       </div>
+    </div>
     </div>
   </div>
 

--- a/src/stylesheets/project_specific/styleguidepage/styleguidepage.scss
+++ b/src/stylesheets/project_specific/styleguidepage/styleguidepage.scss
@@ -147,52 +147,69 @@ pre[class*="language-"] {
 
 .little-box {
   display: inline-block;
-  background:  nth($mz-scarlets, 1);
+  background: $mz-scarlet-1;
   color: white;
   text-align: center;
 }
 
-.mz-darkpurples1 {
-  background-color: nth($mz-darkpurples, 1);
+.mz-darkpurples1,
+.mz-darkpurple-1 {
+  background-color: $mz-darkpurple-1;
 }
-.mz-darkpurples2 {
-  background-color: nth($mz-darkpurples, 2);
+.mz-darkpurples2,
+.mz-darkpurple-2 {
+  background-color: $mz-darkpurple-2;
 }
-.mz-darkpurples3 {
-  background-color: nth($mz-darkpurples, 3);
+.mz-darkpurples3,
+.mz-darkpurple-3 {
+  background-color: $mz-darkpurple-3;
 }
-.mz-darkpurples4 {
-  background-color: nth($mz-darkpurples, 4);
+.mz-darkpurples4,
+.mz-darkpurple-4 {
+  background-color: $mz-darkpurple-4;
 }
-
-.mz-scarlets1 {
-  background-color: nth($mz-scarlets, 1);
-}
-.mz-scarlets2 {
-  background-color: nth($mz-scarlets, 2);
-}
-.mz-scarlets3 {
-  background-color: nth($mz-scarlets, 3);
+.mz-darkpurples5,
+.mz-darkpurple-5 {
+  background-color: $mz-darkpurple-5;
 }
 
-.mz-pinks1 {
-  background-color: nth($mz-pinks, 1);
+.mz-scarlets1,
+.mz-scarlet-1 {
+  background-color: $mz-scarlet-1;
 }
-.mz-pinks2 {
-  background-color: nth($mz-pinks, 2);
+.mz-scarlets2,
+.mz-scarlet-2 {
+  background-color: $mz-scarlet-2;
 }
-.mz-pinks3 {
-  background-color: nth($mz-pinks, 3);
+.mz-scarlets3,
+.mz-scarlet-3 {
+  background-color: $mz-scarlet-3;
 }
 
-.mz-purples1 {
-  background-color: nth($mz-purples, 1);
+.mz-pinks1,
+.mz-pink-1 {
+  background-color: $mz-pink-1;
 }
-.mz-purples2 {
-  background-color: nth($mz-purples, 2);
+.mz-pinks2,
+.mz-pink-2 {
+  background-color: $mz-pink-2;
 }
-.mz-purples3 {
-  background-color: nth($mz-purples, 3);
+.mz-pinks3,
+.mz-pink-3 {
+  background-color: $mz-pink-3;
+}
+
+.mz-purples1,
+.mz-purple-1 {
+  background-color: $mz-purple-1;
+}
+.mz-purples2,
+.mz-purple-2 {
+  background-color: $mz-purple-2;
+}
+.mz-purples3,
+.mz-purple-3 {
+  background-color: $mz-purple-3;
 }
 
 .mz-black {


### PR DESCRIPTION
Adds dark purple number 5 to the styleguide documentation. Additional tweaks:

- Creates the class `mz-darkpurple-5` to fulfill this styling.
- Colors are based on three columns instead of four.
- Provide an alternate way of writing class names without plurals, e.g. `mz-pink-2` throughout. The original class names are currently preserved for backwards compatibility.
- Constrains color tables to the column width.

Resolves #503.