### PR TITLE
Use integer border widths on avatars

### DIFF
--- a/src/stylesheets/common/_components.scss
+++ b/src/stylesheets/common/_components.scss
@@ -86,7 +86,7 @@ img.avatar-byline {
   height: 42px;
   margin-right: 0.5em;
   padding: 2px;
-  border: 1.5px solid nth($mz-darkpurples, 1);
+  border: 2px solid $mz-darkpurple-1;
   border-radius: 50%;
   box-shadow: inset 0 0 0 3px white;
 }

--- a/src/stylesheets/common/avatar.scss
+++ b/src/stylesheets/common/avatar.scss
@@ -4,7 +4,6 @@
   }
 }
 
-
 // Used in author bio at end of article
 img.avatar {
   position: relative;
@@ -12,7 +11,7 @@ img.avatar {
   height: 64px;
   margin-right: 0.5em;
   padding: 2px;
-  border: 1.5px solid nth($mz-darkpurples, 1);
+  border: 2px solid $mz-darkpurple-1;
   border-radius: 50%;
   box-shadow: inset 0 0 0 3px white;
 }
@@ -23,7 +22,7 @@ img.avatar-about {
   width: 42px;
   height: 42px;
   padding: 2px;
-  border: 1.5px solid nth($mz-darkpurples, 1);
+  border: 2px solid $mz-darkpurple-1;
   border-radius: 50%;
   box-shadow: inset 0 0 0 3px white;
   z-index: 1;
@@ -37,15 +36,15 @@ img.avatar-about {
 /*inside of dashboard*/
 .profile-picture{
   border-radius: 50%;
-  border:1.5px solid nth($mz-darkpurples, 1);
-  padding:2px;
+  border: 2px solid $mz-darkpurple-1;
+  padding: 2px;
 }
 
 img.dashboard-profile-pic{
   @extend .profile-picture;
-  margin-top:-10px;
-  width:60px;
-  height:60px;
-  float:left;
-  box-shadow: 30px #FFF inset;
+  margin-top: -10px;
+  width: 60px;
+  height: 60px;
+  float: left;
+  box-shadow: 30px white inset;
 }


### PR DESCRIPTION
Not sure when this started happening, but at some point, Chrome on non-retina screens would round fractional border widths in such a way that would cause the border to no longer be equal width all around:

![screenshot 2017-06-30 10 32 45](https://user-images.githubusercontent.com/2553268/27740372-ca431ba2-5d7f-11e7-8bba-6b28fa8bc542.png)

We were specifying a border width of `1.5px` -- possibly to dial in an exact desired width on Retina (or other high-pixel-density screens) but this is no longer gracefully degrading on normal monitors.

I recommend rounding up to 2px. This means the border width is still more or less the same on normal monitors but the circles are now evenly balanced:

![screenshot 2017-06-30 10 34 48](https://user-images.githubusercontent.com/2553268/27740474-24db3cac-5d80-11e7-8c17-53a13e310aaa.png)

Note that Firefox rounded down to 1px, instead of up to 2px. By making this fix, we are more consistent across browser experiences.

In addition, I've made some code style fixes to `avatar.scss`.