### PR TITLE
Tweak editor banner styles

### DIFF
--- a/src/stylesheets/project_specific/website/_index-editor-snippet.scss
+++ b/src/stylesheets/project_specific/website/_index-editor-snippet.scss
@@ -1,18 +1,19 @@
-$gradient-color: nth($mz-darkpurples, 1);
+$editor-gradient-color: $mz-darkpurple-1;
+$editor-border-radius: 5px;
 
 .editor-wrapper {
   width: 100%;
   height: $section-height - $section-padding*2;
-  border-radius: 5px;
+  border-radius: $editor-border-radius;
   overflow: hidden;
 
   &::before {
+    content: '';
     width: 100%;
     height: 100%;
-    border-radius: 5px;
-    content: ' ';
-    background: -webkit-linear-gradient(rgba($gradient-color, 0) 25%, $gradient-color 97%);
-    background: linear-gradient(rgba($gradient-color, 0) 25%, $gradient-color 97%);
+    border-radius: $editor-border-radius;
+    background: -webkit-linear-gradient(rgba($editor-gradient-color, 0) 25%, $editor-gradient-color 97%);
+    background: linear-gradient(rgba($editor-gradient-color, 0) 25%, $editor-gradient-color 97%);
     position: absolute;
     pointer-events: none;
   }
@@ -34,12 +35,12 @@ $gradient-color: nth($mz-darkpurples, 1);
 
   // Syntax highlighting
   .cp, .nt {
-    color: #FF112F;
+    color: #ff112f;
   }
   .na {
-    color: nth($mz-pinks, 2);
+    color: $mz-pink-2;
   }
   .s {
-    color: nth($mz-purples, 2);
+    color: $mz-purple-2;
   }
 }

--- a/src/stylesheets/project_specific/website/_index-editor-snippet.scss
+++ b/src/stylesheets/project_specific/website/_index-editor-snippet.scss
@@ -1,27 +1,40 @@
 $gradient-color: nth($mz-darkpurples, 1);
-$editor-right-margin: 32px;
 
-.editor-snippet {
-  @media (min-width: $screen-sm) {
+.editor-wrapper {
+  width: 100%;
+  height: $section-height - $section-padding*2;
+  border-radius: 5px;
+  overflow: hidden;
+
+  &::before {
     width: 100%;
-    height: $section-height - $section-padding*2;
-    border: 0;
-    color: #fff;
-    background-color: #1e0f33;
-    border-radius: 5px;
-    overflow-x: hidden;
-    overflow-y: scroll;
-    margin: 0;
-    padding: 0;
-  }
-  &:before {
-    width: 100%;
-    height: $section-height - $section-padding*2;
+    height: 100%;
     border-radius: 5px;
     content: ' ';
     background: -webkit-linear-gradient(rgba($gradient-color, 0) 25%, $gradient-color 97%);
     background: linear-gradient(rgba($gradient-color, 0) 25%, $gradient-color 97%);
     position: absolute;
+    pointer-events: none;
+  }
+}
+
+.editor-snippet {
+  @media (min-width: $screen-sm) {
+    width: 100%;
+    height: 100%;
+    border: 0;
+    color: #fff;
+    background-color: #1e0f33;
+    overflow-x: hidden;
+    overflow-y: scroll;
+    margin: 0;
+    padding: 1.5em;
+    padding-right: 3em;
+  }
+
+  // Scroll bar adjustments, Webkit only
+  &::-webkit-scrollbar-track-piece {
+    background-color: transparent;
   }
 
   // Syntax highlighting

--- a/src/stylesheets/project_specific/website/_index-editor-snippet.scss
+++ b/src/stylesheets/project_specific/website/_index-editor-snippet.scss
@@ -32,11 +32,6 @@ $gradient-color: nth($mz-darkpurples, 1);
     padding-right: 3em;
   }
 
-  // Scroll bar adjustments, Webkit only
-  &::-webkit-scrollbar-track-piece {
-    background-color: transparent;
-  }
-
   // Syntax highlighting
   .cp, .nt {
     color: #FF112F;

--- a/src/stylesheets/project_specific/website/_section.scss
+++ b/src/stylesheets/project_specific/website/_section.scss
@@ -31,6 +31,7 @@
     margin-top: 0;
   }
 }
+
 .with-background {
   h1, h2, h3, h4, h5, h6, p {
     color: #ffffff;
@@ -47,6 +48,13 @@
 
   @media (min-width: $screen-sm) {
     background-image: url('/common/styleguide/images/background/contour_purple_lg.png');
+  }
+}
+
+.with-background.scarlet-contour {
+  /* Improve readability adding slight contrast to the text */
+  h1, h2, h3, h4, h5, h6, p {
+    text-shadow: 1px 1px 2px $mz-purple-2;
   }
 }
 


### PR DESCRIPTION
Some things were bugging me...

__Before:__
![screenshot 2017-08-28 18 07 12](https://user-images.githubusercontent.com/2553268/29795787-c6560d72-8c1b-11e7-80fa-b4fd6bf0f067.png)

__After:__
![screenshot 2017-08-28 18 03 49](https://user-images.githubusercontent.com/2553268/29795786-c654abf8-8c1b-11e7-8e5d-778e330ffb4a.png)

Changelog

- Provide some padding so that the editor content isn't riding up against the top of the box. Note that the text also should have one level of indent less so that the padding is even. (see PR https://github.com/mapzen/website/pull/1823)
- This necessitated moving the gradient to the `.editor-wrapper` element, and the property `pointer-events:none;` is added to it so that people can click through it.
- Move height to `.editor-wrapper` so that it only needs to be defined in one place
- Moved definition of border radius and overflow so that the scrollbar does not square up the edges

I also added a bit of a purple text-shadow to make the white text stand out better on the background.