### PR TITLE
Adjust headings at h4, h5, h6, resolves #524

### DIFF
--- a/src/stylesheets/common/_typography.scss
+++ b/src/stylesheets/common/_typography.scss
@@ -65,11 +65,7 @@ h4 {
   }
 }
 
-h5 {
-  font-size: 18px;
-}
-
-h6 {
+h5, h6 {
   font-size: 16px;
 }
 

--- a/src/stylesheets/common/_typography.scss
+++ b/src/stylesheets/common/_typography.scss
@@ -44,30 +44,33 @@ h2 {
 h3 {
   font-size: 24px;
   @media (max-width: $screen-sm) {
+    font-size: 20px;
+  }
+}
+
+h4, h5, h6 {
+  margin-top: 24px;
+  margin-bottom: 12px;
+
+  // Scale back margins on mobile
+  @media (max-width: $screen-sm) {
+    margin-bottom: 6px;
+  }
+}
+
+h4 {
+  font-size: 20px;
+  @media (max-width: $screen-sm) {
     font-size: 18px;
   }
 }
 
-// For use in blogs
-h4 {
-  font-size: 16px;
-  // margin: 0px;
-  // padding: 0px;
-  margin-top: 24px;
-  margin-bottom: 12px;
-  @media (min-width: $screen-sm) {
-    // font-size: 24px;
-    // margin-top: 30px;
-    // margin-bottom: 10px;
-  }
+h5 {
+  font-size: 18px;
 }
 
-// footer get involved
-h5 {
-  font-size: 14px;
-  margin-top: 24px;
-  margin-bottom: 12px;
-  // color: $mz-mediumgray;
+h6 {
+  font-size: 16px;
 }
 
 // link color was missing from style guide


### PR DESCRIPTION
This pulls in the slightly higher `h4` size that we used in the [FOSS4G events page](https://mapzen.com/events/foss4g2017/) since we found that under the current heading scale, there is too much of a size difference between `h3` and `h4`. An intermediary size between those would have really helped.

Also, the current `h5` is defined as `14px` - smaller than the body text size at `16px`. Headings at smaller point sizes than text can be very awkward (unless they have been defined this way on purpose for stylistic purposes, which I don't believe these are). So `h6` is redefined to be a heading at the same size as body text (`16px`) -- basically just a bold version of body text -- and `h5` is given another intermediary size at `18px`. 