### PR TITLE
Add card component

### DIFF
--- a/src/site/includes/side-nav.html
+++ b/src/site/includes/side-nav.html
@@ -27,6 +27,7 @@
         <li><a href="./ui-components.html#user-avatar">User Avatars</a></li>
         <li><a href="./ui-components.html#author-blurb-single">Author Blurb</a></li>
         <li><a href="./ui-components.html#signup-cta">Sign Up CTA</a></li>
+        <li><a href="./ui-components.html#card">Cards</a></li>
         <li><a href="./ui-components.html#switcher">Switcher</a></li>
         <li><a href="./ui-components.html#loading-spinner">Loading Spinners</a></li>
       </ul>

--- a/src/site/ui-components.html
+++ b/src/site/ui-components.html
@@ -17,6 +17,7 @@
         @@include('./ui-components/author-blurb/single.html')
         @@include('./ui-components/author-blurb/multiple.html')
         @@include('./ui-components/signup-cta/index.html')
+        @@include('./ui-components/card/index.html')
         @@include('./ui-components/switcher/index.html')
         @@include('./ui-components/loading-spinner/index.html')
       </div>

--- a/src/site/ui-components/card/index.html
+++ b/src/site/ui-components/card/index.html
@@ -4,7 +4,7 @@
     A card is a simple container used to display a collection of elements (e.g., an icon, title, text, and button). Use a collection of cards when you want to show related content of equal hierarchy.
   </p>
   <p>
-    Cards expand to fill the width of their parent, so use in combination with responsive columns. The height of a card will vary depending on the card content.
+    Cards expand to fill the width of their parent, so use in combination with responsive columns. By default, the height of a card will vary depending on the card content.
   </p>
 
   <div data-xrayhtml>
@@ -29,4 +29,31 @@
       </div>
     </div>
   </div>
+
+  <p>
+    To force cards to be the same height, add the class "cards" to their parent div.  Though please note that this is <strong>not supported in IE9</strong> and earlier.
+  </p>
+
+  <div data-xrayhtml>
+    <div class="row cards">
+      <div class="col-xs-6 col-sm-4">
+        <div class="card">
+          <div class="card-content">
+            <div class="card-title">API explorer</div>
+            <p>Mobility Explorer lets you query and visualize Transitland data and shows the isochrones and Map Matching services at work.</p>
+          </div>
+        </div>
+      </div>
+      <div class="col-xs-6 col-sm-4">
+        <div class="card">
+          <div class="card-content">
+            <div class="card-title">Map matching</div>
+            <p>Snap a noisy GPS trace to the actual road or path you traveled.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+
 </div>

--- a/src/site/ui-components/card/index.html
+++ b/src/site/ui-components/card/index.html
@@ -1,0 +1,32 @@
+<div id="card" class="headroom-large">
+  <h5>Cards</h5>
+  <p>
+    A card is a simple container used to display a collection of elements (e.g., an icon, title, text, and button). Use a collection of cards when you want to show related content of equal hierarchy.
+  </p>
+  <p>
+    Cards expand to fill the width of their parent, so use in combination with responsive columns. The height of a card will vary depending on the card content.
+  </p>
+
+  <div data-xrayhtml>
+    <div class="row">
+      <div class="col-xs-6 col-sm-4">
+        <div class="card">
+          <div class="card-content">
+            <div class="card-title">API explorer</div>
+            <p>Mobility Explorer lets you query and visualize Transitland data and shows the isochrones and Map Matching services at work.</p>
+            <button class="btn btn-with-arrow">Learn more</button>
+          </div>
+        </div>
+      </div>
+      <div class="col-xs-6 col-sm-4">
+        <div class="card no-border text-center">
+          <div class="card-content">
+            <span class="icon-lg icon-folding-map-circle"></span>
+            <div class="card-title">Map matching</div>
+            <p>Snap a noisy GPS trace to the actual road or path you traveled.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/stylesheets/common/_card.scss
+++ b/src/stylesheets/common/_card.scss
@@ -33,3 +33,14 @@ $card-content-color: $mz-mediumgray;
   }
 
 }
+
+.cards, .cards div[class^="col-"] {
+  display: -webkit-flex; /* Safari */
+  display: flex;
+
+  .card {
+    -webkit-flex: 1;  /* Safari 6.1+ */
+    -ms-flex: 1;  /* IE 10 */    
+    flex: 1;
+  }
+}

--- a/src/stylesheets/common/_card.scss
+++ b/src/stylesheets/common/_card.scss
@@ -1,0 +1,35 @@
+/*
+ * Card
+ *
+ * .card
+ *  -> .card-image (proposed only)
+ *  -> .card-content
+ *    -> .card-title
+ *    -> .card-icon (proposed only)
+ *    -> .card-action (proposed only)
+ */
+
+$card-border-color: #ccc; //$mz-lightgray;
+$card-content-color: $mz-mediumgray;
+
+.card {
+  border: 1px solid $card-border-color;
+  word-wrap: break-word;
+
+  &.no-border {
+    border-color: transparent;
+  }
+
+  .card-content {
+    margin: 10%;
+    word-wrap: break-word;
+    color: $card-content-color;
+  }
+
+  .card-title {
+    @extend h4;
+    color: nth($mz-darkpurples, 2);
+    word-wrap: break-word;
+  }
+
+}

--- a/src/stylesheets/common/_card.scss
+++ b/src/stylesheets/common/_card.scss
@@ -1,13 +1,4 @@
-/*
- * Card
- *
- * .card
- *  -> .card-image (proposed only)
- *  -> .card-content
- *    -> .card-title
- *    -> .card-icon (proposed only)
- *    -> .card-action (proposed only)
- */
+// Card
 
 $card-border-color: #ccc; //$mz-lightgray;
 $card-content-color: $mz-mediumgray;
@@ -34,6 +25,7 @@ $card-content-color: $mz-mediumgray;
 
 }
 
+// Use "cards" parent div to force cards to same height
 .cards, .cards div[class^="col-"] {
   display: -webkit-flex; /* Safari */
   display: flex;

--- a/src/stylesheets/styleguide.scss
+++ b/src/stylesheets/styleguide.scss
@@ -17,6 +17,7 @@
 @import 'common/buttons';
 @import 'common/bylines';
 @import 'common/breadcrumb';
+@import 'common/card';
 @import 'common/category-list';
 @import 'common/components';
 @import 'common/cta';


### PR DESCRIPTION
Add a lightweight "card" component to the styleguide.  We'll use this frequently with the new product roll-up pages.  (Also includes the option of forcing the cards to be the same height.)

Preview: https://precog.mapzen.com/mapzen/styleguide/rfriberg/new-cards/ui-components.html#card

Sidenote: @souperneon - do we use the "feature card" component anywhere?  I'm wondering if that's still relevant for the styleguide or if we could remove. 
