### PR TITLE
deploy master branch to dev and prod

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,6 +15,7 @@ deployment:
     branch: master
     commands:
       - gulp publish --target prod
+      - gulp publish --target dev
 
 general:
   artifacts:


### PR DESCRIPTION
Seems bad to me that dev.mapzen.com is referencing an out-of-date styleguide version. Let's deploy to dev and prod from master?