### PR TITLE
Change image urls to relative paths

### DIFF
--- a/src/stylesheets/common/_footer.scss
+++ b/src/stylesheets/common/_footer.scss
@@ -21,7 +21,7 @@ body.no-footer {
   color: nth($mz-darkpurples, 4);
   padding-top: 50px;
   background-color: nth($mz-darkpurples, 1);
-  background: url('/common/styleguide/images/background/contour_darkpurple_xs.png');
+  background: url('../images/background/contour_darkpurple_xs.png');
   background-size: cover;
   border-top: 5px solid nth($mz-scarlets, 2);
 
@@ -36,11 +36,11 @@ body.no-footer {
   }
 
   @media (min-width: $screen-xs) {
-    background-image: url('/common/styleguide/images/background/contour_darkpurple_sm.png');
+    background-image: url('../images/background/contour_darkpurple_sm.png');
   }
 
   @media (min-width: $screen-sm) {
-    background-image: url('/common/styleguide/images/background/contour_darkpurple2_lg.png');
+    background-image: url('../images/background/contour_darkpurple2_lg.png');
     background-attachment: fixed;
     background-position: center center;
   }
@@ -93,7 +93,7 @@ body.no-footer {
 .compass-logo {
   width: 36px;
   height: 36px;
-  background-image: url('https://mapzen.com/common/styleguide/images/logos/mapzen-logo-compass-white.png');
+  background-image: url('../images/logos/mapzen-logo-compass-white.png');
   background-repeat: no-repeat;
   background-size: 36px;
   margin: 6px auto;

--- a/src/stylesheets/common/_icons.scss
+++ b/src/stylesheets/common/_icons.scss
@@ -47,13 +47,13 @@ span.icon {
 }
 
 .icon-award-ribbon-circle {
-  background-image: url('https://mapzen.com/common/styleguide/images/icons/award-ribbon-circle.svg');
+  background-image: url('../images/icons/award-ribbon-circle.svg');
 }
 
 .icon-dollar-sign-circle {
-  background-image: url('https://mapzen.com/common/styleguide/images/icons/dollar-sign-circle.svg');
+  background-image: url('../images/icons/dollar-sign-circle.svg');
 }
 
 .icon-folding-map-circle {
-  background-image: url('https://mapzen.com/common/styleguide/images/icons/folding-map-circle.svg');
+  background-image: url('../images/icons/folding-map-circle.svg');
 }

--- a/src/stylesheets/common/_navbar.scss
+++ b/src/stylesheets/common/_navbar.scss
@@ -203,7 +203,7 @@ body.transparent-main-nav nav.navbar {
 .mapzen-logo {
   width: 130px;
   height: 40px;
-  background-image: url('https://mapzen.com/common/styleguide/images/mapzen-logo-stacked.png');
+  background-image: url('../images/mapzen-logo-stacked.png');
   background-repeat: no-repeat;
   background-size: 130px;
   background-position: 0 0;
@@ -224,7 +224,7 @@ body.transparent-main-nav nav.navbar {
   }
 
   @media #{$hidpi-screens} {
-    background-image: url('https://mapzen.com/common/styleguide/images/mapzen-logo-stacked@2x.png');
+    background-image: url('../images/mapzen-logo-stacked@2x.png');
   }
 }
 

--- a/src/stylesheets/project_specific/website/_index-hero-video.scss
+++ b/src/stylesheets/project_specific/website/_index-hero-video.scss
@@ -7,7 +7,7 @@
   background-repeat: no-repeat;
   background-position: center center;
   background-size: cover;
-  background-image: url('/common/styleguide/images/background/contour_purple_xs.png');
+  background-image: url('../images/background/contour_purple_xs.png');
   @media (min-width: $screen-sm) {
     min-height: 550px;
     height: calc(100vh - #{$header-height});
@@ -81,7 +81,7 @@
     right: -40px; /* to hide control*/
     pointer-events: none;
     transform: scale(1.004, 1);
-    background-image: url('/common/styleguide/images/main-preview.jpg');
+    background-image: url('../images/main-preview.jpg');
     background-size: 100% 100%;
     animation-name: fadein;
     animation-duration: 1s;

--- a/src/stylesheets/project_specific/website/_map-gallery.scss
+++ b/src/stylesheets/project_specific/website/_map-gallery.scss
@@ -55,27 +55,27 @@ $map-gallery-xs-height: 256px;
     }
   }
   .refill {
-    background-image: url(/common/styleguide/images/maps/refill.png);
+    background-image: url(../images/maps/refill.png);
     @media #{$hidpi-screens} {
-      background-image: url(/common/styleguide/images/maps/refill@2x.png);
+      background-image: url(../images/maps/refill@2x.png);
     }
   }
   .tron {
-    background-image: url(/common/styleguide/images/maps/tron.png);
+    background-image: url(../images/maps/tron.png);
     @media #{$hidpi-screens} {
-      background-image: url(/common/styleguide/images/maps/tron@2x.png);
+      background-image: url(../images/maps/tron@2x.png);
     }
   }
   .walkabout {
-    background-image: url(/common/styleguide/images/maps/walkabout.png);
+    background-image: url(../images/maps/walkabout.png);
     @media #{$hidpi-screens} {
-      background-image: url(/common/styleguide/images/maps/walkabout@2x.png);
+      background-image: url(../images/maps/walkabout@2x.png);
     }
   }
   .bubble {
-    background-image: url(/common/styleguide/images/maps/bubble-wrap.png);
+    background-image: url(../images/maps/bubble-wrap.png);
     @media #{$hidpi-screens} {
-      background-image: url(/common/styleguide/images/maps/bubble-wrap@2x.png);
+      background-image: url(../images/maps/bubble-wrap@2x.png);
     }
   }
 }

--- a/src/stylesheets/project_specific/website/_section.scss
+++ b/src/stylesheets/project_specific/website/_section.scss
@@ -40,14 +40,14 @@
 
 .purple-contour {
   background-color: $mz-purple-2;
-  background-image: url('/common/styleguide/images/background/contour_purple_xs.png');
+  background-image: url('../images/background/contour_purple_xs.png');
 
   @media (min-width: $screen-xs) {
-    background-image: url('/common/styleguide/images/background/contour_purple_sm.png');
+    background-image: url('../images/background/contour_purple_sm.png');
   }
 
   @media (min-width: $screen-sm) {
-    background-image: url('/common/styleguide/images/background/contour_purple_lg.png');
+    background-image: url('../images/background/contour_purple_lg.png');
   }
 }
 
@@ -60,13 +60,13 @@
 
 .scarlet-contour {
   background-color: $mz-scarlet-2;
-  background-image: url('/common/styleguide/images/background/contour_scarlet_xs.png');
+  background-image: url('../images/background/contour_scarlet_xs.png');
 
   @media (min-width: $screen-xs) {
-    background-image: url('/common/styleguide/images/background/contour_scarlet_sm.png');
+    background-image: url('../images/background/contour_scarlet_sm.png');
   }
 
   @media (min-width: $screen-sm) {
-    background-image: url('/common/styleguide/images/background/contour_scarlet_lg.png');
+    background-image: url('../images/background/contour_scarlet_lg.png');
   }
 }


### PR DESCRIPTION
First step towards publishing via github: change references (like `/common/styleguide/`) to relative urls.

@hanbyul-here - do you know if there was any reason we were [mostly](https://github.com/mapzen/styleguide/blob/f4afa6eac3a7363e99f35279efadc57a7c1ee69a/src/stylesheets/project_specific/developer/_developer-login.scss#L123) avoiding this in the past?